### PR TITLE
Adding timed proposal voting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "edge-governance"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -655,7 +655,7 @@ name = "edgeware-runtime"
 version = "0.1.1"
 dependencies = [
  "edge-delegation 0.1.2",
- "edge-governance 0.1.2",
+ "edge-governance 0.1.0",
  "edge-identity 0.1.3",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/modules/edge-governance/Cargo.toml
+++ b/modules/edge-governance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edge-governance"
-version = "0.1.2"
+version = "0.1.0"
 authors = ["Jake Naviasky <jake@commonwealth.im>, Drew Stone <drew@commonwealth.im>"]
 
 [dependencies]

--- a/modules/edge-governance/src/governance.rs
+++ b/modules/edge-governance/src/governance.rs
@@ -78,6 +78,7 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
+		/// Creates a new governance proposal in the chosen category.
 		pub fn create_proposal(origin, title: Vec<u8>, contents: Vec<u8>, category: ProposalCategory) -> Result {
 			let _sender = ensure_signed(origin)?;
 			ensure!(!title.is_empty(), "Proposal must have title");
@@ -108,6 +109,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Add a new comment to an existing governance proposal.
 		// TODO: give comments unique numbers/ids?
 		pub fn add_comment(origin, proposal_hash: T::Hash, comment: Vec<u8>) -> Result {
 			let _sender = ensure_signed(origin)?;
@@ -123,6 +125,8 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Advance a governance proposal into the "voting" stage. Can only be
+		/// performed by the original author of the proposal.
 		pub fn advance_proposal(origin, proposal_hash: T::Hash) -> Result {
 			let _sender = ensure_signed(origin)?;
 			let record = <ProposalOf<T>>::get(&proposal_hash).ok_or("Proposal does not exist")?;
@@ -142,6 +146,8 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Submit or update a vote on a proposal. The proposal must be in the
+		/// "voting" stage.
 		pub fn submit_vote(origin, proposal_hash: T::Hash, vote: bool) -> Result {
 			let _sender = ensure_signed(origin)?;
 			let record = <ProposalOf<T>>::get(&proposal_hash).ok_or("Proposal does not exist")?;
@@ -184,10 +190,16 @@ decl_event!(
 	pub enum Event<T> where <T as system::Trait>::Hash,
 							<T as system::Trait>::AccountId,
 							<T as system::Trait>::BlockNumber {
+		/// Emitted at proposal creation: (Creator, ProposalHash)
 		NewProposal(AccountId, Hash),
+		/// Emitted at comment creation: (Commentor, ProposalHash)
 		NewComment(AccountId, Hash),
+		/// Emitted when voting begins: (ProposalHash, VotingEndTime)
 		VotingStarted(Hash, BlockNumber),
+		/// Emitted when a vote is submitted: (ProposalHash, Voter, Vote)
 		VoteSubmitted(Hash, AccountId, bool),
+		/// Emitted when voting is completed: (ProposalHash)
+		// TODO: also have this contain the final result
 		VotingCompleted(Hash),
 	}
 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -236,7 +236,7 @@ construct_runtime!(
 		UpgradeKey: upgrade_key,
 		Identity: identity::{Module, Call, Storage, Config<T>, Event<T>},
 		Delegation: delegation::{Module, Call, Storage, Event<T>},
-		Governance: governance::{Module, Call, Storage, Event<T>},
+		Governance: governance::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 );
 

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -162,7 +162,7 @@ fn testnet_genesis(
 			claims_issuers: initial_authorities.iter().cloned().map(Into::into).collect(),
 		}),
 		governance: Some(GovernanceConfig {
-			voting_time: (60 / 5) * 60 * 24 * 7, // 1 week
+			voting_time: 10000,
 		}),
 	}
 }

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use edgeware_runtime::{
 	AccountId, BalancesConfig, ConsensusConfig, GenesisConfig, IdentityConfig, SessionConfig,
-	TimestampConfig, UpgradeKeyConfig,
+	TimestampConfig, UpgradeKeyConfig, GovernanceConfig
 };
 use primitives::{ed25519, AuthorityId};
 use substrate_service;
@@ -157,9 +157,12 @@ fn testnet_genesis(
 			key: upgrade_key,
 		}),
 		identity: Some(IdentityConfig {
-	  verifiers: initial_authorities.iter().cloned().map(Into::into).collect(),
-	  expiration_time: 10000,
+			verifiers: initial_authorities.iter().cloned().map(Into::into).collect(),
+			expiration_time: 10000,
 			claims_issuers: initial_authorities.iter().cloned().map(Into::into).collect(),
+		}),
+		governance: Some(GovernanceConfig {
+			voting_time: (60 / 5) * 60 * 24 * 7, // 1 week
 		}),
 	}
 }


### PR DESCRIPTION
This update changes:
* Proposals now end after a set number of blocks, configured in the GenesisConfig. This is currently set to an arbitrary 10,000 blocks.
* Funding proposals no longer contain a balance parameter -- we can add this alongside all the other governance execution-related actions.