### PR TITLE
Cleaning up identity enums to help with marshalling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "edge-identity"
-version = "0.1.4"
+version = "0.1.0"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -656,7 +656,7 @@ version = "0.1.1"
 dependencies = [
  "edge-delegation 0.1.2",
  "edge-governance 0.1.2",
- "edge-identity 0.1.4",
+ "edge-identity 0.1.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "edge-delegation"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "edge-governance"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -654,8 +654,8 @@ dependencies = [
 name = "edgeware-runtime"
 version = "0.1.1"
 dependencies = [
- "edge-delegation 0.1.2",
- "edge-governance 0.1.2",
+ "edge-delegation 0.1.0",
+ "edge-governance 0.1.0",
  "edge-identity 0.1.0",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "edge-identity"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -656,7 +656,7 @@ version = "0.1.1"
 dependencies = [
  "edge-delegation 0.1.2",
  "edge-governance 0.1.2",
- "edge-identity 0.1.3",
+ "edge-identity 0.1.4",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/modules/edge-delegation/Cargo.toml
+++ b/modules/edge-delegation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edge-delegation"
-version = "0.1.2"
+version = "0.1.0"
 authors = ["Drew Stone <drew@commonwealth.im>"]
 
 [dependencies]

--- a/modules/edge-governance/Cargo.toml
+++ b/modules/edge-governance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edge-governance"
-version = "0.1.2"
+version = "0.1.0"
 authors = ["Jake Naviasky <jake@commonwealth.im>, Drew Stone <drew@commonwealth.im>"]
 
 [dependencies]

--- a/modules/edge-identity/Cargo.toml
+++ b/modules/edge-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edge-identity"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Drew Stone <drew@commonwealth.im>"]
 
 [dependencies]

--- a/modules/edge-identity/Cargo.toml
+++ b/modules/edge-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edge-identity"
-version = "0.1.4"
+version = "0.1.0"
 authors = ["Drew Stone <drew@commonwealth.im>"]
 
 [dependencies]


### PR DESCRIPTION
This small fix removes the BlockNumber parameter from the IdentityStage enum. The API was having trouble handling the type, this makes things much easier.