### PR TITLE
Fixing delegation warnings and adding storage tests.

### DIFF
--- a/modules/edge-delegation/src/delegation.rs
+++ b/modules/edge-delegation/src/delegation.rs
@@ -36,7 +36,7 @@ extern crate srml_system as system;
 
 use rstd::prelude::*;
 use system::ensure_signed;
-use runtime_support::{StorageValue, StorageMap, Parameter};
+use runtime_support::{StorageMap};
 use runtime_support::dispatch::Result;
 
 pub trait Trait: balances::Trait {


### PR DESCRIPTION
Changes:
* Delegation module was emitting some warnings, mostly about `#[macro_use]` and similar, so I fixed those.
* I added verification in _successful tests only_ of storage contents. We need to decide whether to, and, if so, how we might verify storage contents in failed tests.