### PR TITLE
Identity feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,8 +598,10 @@ dependencies = [
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-consensus 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-support 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-system 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-timestamp 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-keyring 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]

--- a/modules/edge-identity/Cargo.toml
+++ b/modules/edge-identity/Cargo.toml
@@ -17,6 +17,8 @@ sr-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 sr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-support = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-system = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-consensus = { git = "https://github.com/paritytech/substrate", default-features = false }
 
 [features]
 default = ["std"]
@@ -32,4 +34,6 @@ std = [
     "srml-support/std",
     "sr-primitives/std",
     "srml-system/std",
+    "srml-timestamp/std",
+    "srml-consensus/std",
 ]

--- a/modules/edge-identity/src/identity.rs
+++ b/modules/edge-identity/src/identity.rs
@@ -247,11 +247,9 @@ decl_module! {
 		/// Remove a claim as a claims issuer. Ensures that the sender is an active
 		/// claims issuer. Ensures that the sender has issued a claim over the
 		/// identity provided to the module.
-		pub fn remove_claim(origin, identity_hash: T::Hash, issuer_index: usize, claim_index: usize) -> Result {
+		pub fn remove_claim(origin, identity_hash: T::Hash, claim_index: usize) -> Result {
 			let _sender = ensure_signed(origin)?;
 
-			let issuers: Vec<T::AccountId> = Self::claims_issuers();
-			ensure!(issuers[issuer_index] == _sender, "Invalid claims issuer");
 			ensure!(<IdentityOf<T>>::exists(identity_hash), "Invalid identity record");
 
 			let mut claims = Self::claims(identity_hash);

--- a/modules/edge-identity/src/lib.rs
+++ b/modules/edge-identity/src/lib.rs
@@ -152,10 +152,6 @@ mod tests {
 		Identity::verify(Origin::signed(who), identity_hash, vote, verifier_index)
 	}
 
-	fn finalize_verification(who: H256, identity_hash: H256) -> Result {
-		Identity::finalize_verification(Origin::signed(who), identity_hash)
-	}
-
 	fn remove_expired_identity(who: H256, identity_hash: H256) -> Result {
 		Identity::remove_expired_identity(Origin::signed(who), identity_hash)
 	}
@@ -342,7 +338,6 @@ mod tests {
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, true, 0));
-			assert_ok!(finalize_verification(verifier, identity_hash));
 
 			assert_eq!(
 				System::events(),
@@ -437,7 +432,6 @@ mod tests {
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, true, 0));
-			assert_ok!(finalize_verification(verifier, identity_hash));
 			assert_err!(verify_identity(verifier, identity_hash, true, 0), "Already verified");
 			assert_eq!(
 				Identity::identity_of(identity_hash),
@@ -472,7 +466,6 @@ mod tests {
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, true, 0));
-			assert_ok!(finalize_verification(verifier, identity_hash));
 			assert_err!(
 				attest_to_identity(public, identity_hash, attestation),
 				"Already verified"
@@ -634,7 +627,6 @@ mod tests {
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, true, 0));
-			assert_ok!(finalize_verification(verifier, identity_hash));
 
 			assert_err!(
 				register_identity(public, identity),
@@ -673,7 +665,6 @@ mod tests {
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, false, 0));
-			assert_ok!(finalize_verification(verifier, identity_hash));
 
 			let new_identity: &[u8] = b"github.com/drstone";
 			assert_err!(
@@ -710,8 +701,6 @@ mod tests {
 
 			let verifier_2 = H256::from(10);
 			assert_ok!(verify_identity(verifier_2, identity_hash, true, 1));
-			
-			assert_ok!(finalize_verification(verifier_1, identity_hash));
 
 			assert_eq!(
 				System::events(),

--- a/modules/edge-identity/src/lib.rs
+++ b/modules/edge-identity/src/lib.rs
@@ -64,7 +64,7 @@ mod tests {
 	// public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
 	use runtime_primitives::{
 		testing::{Digest, DigestItem, Header, UintAuthorityId},
-		traits::{BlakeTwo256, Hash},
+		traits::{BlakeTwo256, Hash, OnFinalise},
 		BuildStorage,
 	};
 
@@ -150,10 +150,6 @@ mod tests {
 
 	fn verify_identity(who: H256, identity_hash: H256, vote: bool, verifier_index: usize) -> Result {
 		Identity::verify(Origin::signed(who), identity_hash, vote, verifier_index)
-	}
-
-	fn remove_expired_identity(who: H256, identity_hash: H256) -> Result {
-		Identity::remove_expired_identity(Origin::signed(who), identity_hash)
 	}
 
 	fn add_metadata_to_account(
@@ -575,7 +571,7 @@ mod tests {
 
 			Timestamp::set_timestamp(10001);
 
-			assert_ok!(remove_expired_identity(public, identity_hash));
+			<Identity as OnFinalise<u64>>::on_finalise(1);
 
 			let attestation: &[u8] = b"www.proof.com/attest_of_extra_proof";
 			assert_err!(
@@ -628,7 +624,7 @@ mod tests {
 
 			Timestamp::set_timestamp(10001);
 
-			assert_ok!(remove_expired_identity(public, identity_hash));
+			<Identity as OnFinalise<u64>>::on_finalise(1);
 
 			let verifier: H256 = H256::from(9);
 			assert_err!(

--- a/modules/edge-identity/src/lib.rs
+++ b/modules/edge-identity/src/lib.rs
@@ -205,12 +205,16 @@ mod tests {
 
 			let public: H256 = pair.public().0.into();
 
+			let expiration_time = Identity::expiration_time();
+			let now = Timestamp::get();
+			let expires_at = now + expiration_time;
+
 			assert_ok!(register_identity(public, identity));
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
-					event: Event::identity(RawEvent::Register(identity_hash, public))
+					event: Event::identity(RawEvent::Register(identity_hash, public, expires_at))
 				}]
 			);
 			assert_eq!(
@@ -259,18 +263,27 @@ mod tests {
 
 			assert_ok!(register_identity(public, identity));
 
+			let mut expiration_time = Identity::expiration_time();
+			let mut now = Timestamp::get();
+			let registration_expires_at = now + expiration_time;
+
 			let attestation: &[u8] = b"www.proof.com/attest_of_extra_proof";
 			assert_ok!(attest_to_identity(public, identity_hash, attestation));
+
+			expiration_time = Identity::expiration_time();
+			now = Timestamp::get();
+			let attest_expires_at = now + expiration_time;
+
 			assert_eq!(
 				System::events(),
 				vec![
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Register(identity_hash, public))
+						event: Event::identity(RawEvent::Register(identity_hash, public, registration_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Attest(identity_hash, public))
+						event: Event::identity(RawEvent::Attest(identity_hash, public, attest_expires_at))
 					}
 				]
 			);
@@ -350,8 +363,16 @@ mod tests {
 
 			assert_ok!(register_identity(public, identity));
 
+			let mut expiration_time = Identity::expiration_time();
+			let mut now = Timestamp::get();
+			let registration_expires_at = now + expiration_time;
+
 			let attestation: &[u8] = b"www.proof.com/attest_of_extra_proof";
 			assert_ok!(attest_to_identity(public, identity_hash, attestation));
+
+			expiration_time = Identity::expiration_time();
+			now = Timestamp::get();
+			let attest_expires_at = now + expiration_time;
 
 			let verifier = H256::from(9);
 			assert_ok!(verify_identity(verifier, identity_hash, true, 0));
@@ -361,11 +382,11 @@ mod tests {
 				vec![
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Register(identity_hash, public))
+						event: Event::identity(RawEvent::Register(identity_hash, public, registration_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Attest(identity_hash, public))
+						event: Event::identity(RawEvent::Attest(identity_hash, public, attest_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
@@ -548,6 +569,10 @@ mod tests {
 
 			assert_ok!(register_identity(public, identity));
 
+			let expiration_time = Identity::expiration_time();
+			let now = Timestamp::get();
+			let registration_expires_at = now + expiration_time;
+
 			Timestamp::set_timestamp(10001);
 
 			assert_ok!(remove_expired_identity(public, identity_hash));
@@ -563,7 +588,7 @@ mod tests {
 				vec![
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Register(identity_hash, public))
+						event: Event::identity(RawEvent::Register(identity_hash, public, registration_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
@@ -590,8 +615,16 @@ mod tests {
 
 			assert_ok!(register_identity(public, identity));
 
+			let mut expiration_time = Identity::expiration_time();
+			let mut now = Timestamp::get();
+			let registration_expires_at = now + expiration_time;
+
 			let attestation: &[u8] = b"www.proof.com/attest_of_extra_proof";
 			assert_ok!(attest_to_identity(public, identity_hash, attestation));
+
+			expiration_time = Identity::expiration_time();
+			now = Timestamp::get();
+			let attest_expires_at = now + expiration_time;
 
 			Timestamp::set_timestamp(10001);
 
@@ -608,11 +641,11 @@ mod tests {
 				vec![
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Register(identity_hash, public))
+						event: Event::identity(RawEvent::Register(identity_hash, public, registration_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Attest(identity_hash, public))
+						event: Event::identity(RawEvent::Attest(identity_hash, public, attest_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
@@ -710,8 +743,16 @@ mod tests {
 
 			assert_ok!(register_identity(public, identity));
 
+			let mut expiration_time = Identity::expiration_time();
+			let mut now = Timestamp::get();
+			let registration_expires_at = now + expiration_time;
+
 			let attestation: &[u8] = b"www.proof.com/attest_of_extra_proof";
 			assert_ok!(attest_to_identity(public, identity_hash, attestation));
+
+			expiration_time = Identity::expiration_time();
+			now = Timestamp::get();
+			let attest_expires_at = now + expiration_time;
 
 			let verifier_1 = H256::from(9);
 			assert_ok!(verify_identity(verifier_1, identity_hash, true, 0));
@@ -724,11 +765,11 @@ mod tests {
 				vec![
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Register(identity_hash, public))
+						event: Event::identity(RawEvent::Register(identity_hash, public, registration_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),
-						event: Event::identity(RawEvent::Attest(identity_hash, public))
+						event: Event::identity(RawEvent::Attest(identity_hash, public, attest_expires_at))
 					},
 					EventRecord {
 						phase: Phase::ApplyExtrinsic(0),


### PR DESCRIPTION
1) Minimizing on-chain computation
The idea is to avoid searching for items in array by iterating through it and avoid mapping data from one form to another. e.g: We are passing `verifier_index` to `verify` function and then checking `verifiers[verifier_index] == sender` instead of searching if `verifiers` contains `sender`.
I didn't see in any of your modules designed this way, nor any of the [substrate modules](https://github.com/paritytech/substrate/tree/master/srml), so maybe you can help me understand why?
2) Remove `on_finalize`
We are looping through pending identities which is potentially large number, and removing expired identities. I believe this query can be done off-chain, and then we can target only identities that are expired with function `remove_expired_identity`.
3) Metadata
I think metadata is good candidate for decentralized database or storage, because it is not used anywhere in the module.
4) Splitting `verify` function to `verify` and `finalize_verification` and refactor finalization logic
Right now if results of verifications is 50/50, the identity is neither verified nor deleted, so it will stay like that untill it expires, and then its deleted. We can verify it if the majority voted for yes, otherwise we delete it. If majority voted for no, creator account is frozen.
5) Changed `expiration_time` type to `Moment`
Since block period can be changed, and some other factors can change the block production duration, type is changed to timestamp.

And few minor things that can be seen through the code.

Question:
Based on what are we selecting verifiers and claim issuers, and wouldn't that give us power to censor them, as well as the power to censor the users? (Assuming that they can be changed)