### PR TITLE
Converting BlockNumber-related timed events to Moment.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,8 +580,10 @@ dependencies = [
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-balances 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-consensus 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-support 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-system 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-timestamp 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-keyring 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,8 +599,10 @@ dependencies = [
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-consensus 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-support 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-system 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-timestamp 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-keyring 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]

--- a/modules/edge-governance/Cargo.toml
+++ b/modules/edge-governance/Cargo.toml
@@ -18,6 +18,8 @@ sr-primitives = { git = "https://github.com/paritytech/substrate", default-featu
 srml-support = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-system = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-balances = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-consensus = { git = "https://github.com/paritytech/substrate", default-features = false }
 edge-delegation = { path = "../edge-delegation", default-features = false }
 edge-voting = { path = "../edge-voting", default-features = false }
 
@@ -36,5 +38,7 @@ std = [
     "sr-primitives/std",
     "srml-system/std",
     "srml-balances/std",
+    "srml-timestamp/std",
+    "srml-consensus/std",
     "edge-voting/std",
 ]

--- a/modules/edge-identity/Cargo.toml
+++ b/modules/edge-identity/Cargo.toml
@@ -17,6 +17,8 @@ sr-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 sr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-support = { git = "https://github.com/paritytech/substrate", default-features = false }
 srml-system = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false }
+srml-consensus = { git = "https://github.com/paritytech/substrate", default-features = false }
 
 [features]
 default = ["std"]
@@ -32,4 +34,6 @@ std = [
     "srml-support/std",
     "sr-primitives/std",
     "srml-system/std",
+    "srml-timestamp/std",
+    "srml-consensus/std",
 ]

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -212,8 +212,6 @@ impl governance::Trait for Runtime {
 }
 
 impl identity::Trait for Runtime {
-	/// The type for making a claim to an identity.
-	type Claim = Vec<u8>;
 	/// The uniquitous event type.
 	type Event = Event;
 }

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -199,8 +199,10 @@ dependencies = [
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-balances 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-consensus 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-support 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-system 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-timestamp 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
 
@@ -217,8 +219,10 @@ dependencies = [
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-consensus 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-support 0.1.0 (git+https://github.com/paritytech/substrate)",
  "srml-system 0.1.0 (git+https://github.com/paritytech/substrate)",
+ "srml-timestamp 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -159,11 +159,10 @@ fn testnet_genesis(
 		}),
 		identity: Some(IdentityConfig {
 			verifiers: initial_authorities.iter().cloned().map(Into::into).collect(),
-			expiration_time: 10000,
-			claims_issuers: initial_authorities.iter().cloned().map(Into::into).collect(),
+			expiration_time: 604800, // 7 days
 		}),
 		governance: Some(GovernanceConfig {
-			voting_time: 10000,
+			voting_time: 604800, // 7 days
 		}),
 		delegation: Some(DelegationConfig {
 			delegation_depth: 5,


### PR DESCRIPTION
As per https://github.com/hicommonwealth/edgeware-node/pull/35:
> Since block period can be changed, and some other factors can change the block production duration, type is changed to timestamp.

This should also simplify calculations on the front-end.