### PR TITLE
Resolves: #66

### DIFF
--- a/scripts/purge-chain.sh
+++ b/scripts/purge-chain.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
 cat <<EOF
 For more options and help: ./purge-chain.sh --help
-Description: Purges local Substrate chains for DeepBrain Chain.
-Authors: "DeepBrain Chain Community <community@dbc.team>", "Luke Penrod <luke@dbc.team>"
-GitHub Organization: https://github.com/dbc-community
+Description: Purges the local database of installed chains.
 
 EOF
 
 set -e
 
-SCRIPT_VERSION="0.1.0"
+SCRIPT_VERSION="0.1.1"
 
-# * Default messages catagories *
-COLOR_DEFAULT="\033[0m"
-COLOR_ERROR="\033[91m"
-COLOR_INFO="\033[96m"
-COLOR_SUCCESS="\033[92m"
-COLOR_WARNING="\033[93m"
+# * Test color support * #
+totalColors="$(tput colors)"
+if test -t 1 && test -n "$totalColors" && test $totalColors -ge 8; then
+	# * Default messages catagories *
+	COLOR_DEFAULT="\033[0m"
+	COLOR_ERROR="\033[91m"
+	COLOR_INFO="\033[96m"
+	COLOR_SUCCESS="\033[92m"
+	COLOR_WARNING="\033[93m"
+else
+	COLOR_DEFAULT="\033[0m"
+	COLOR_ERROR="$COLOR_DEFAULT"
+	COLOR_INFO="$COLOR_DEFAULT"
+	COLOR_SUCCESS="$COLOR_DEFAULT"
+	COLOR_WARNING="$COLOR_DEFAULT"
+fi
 
 # * Configure directories *
 PROJECT_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -37,7 +45,7 @@ prompt_purge() {
 			rm -rf $dirFullPath
 			break
 			;;
-		No) break;;
+		No) break ;;
 		esac
 	done
 }
@@ -51,26 +59,26 @@ find_chain_name() {
 }
 
 print_help() {
-	echo -e "Cleans local chain specs for DeepBrain Chain.\n" \
+	echo -e "Purges the local database of installed chains.\n" \
 		"Usage ./purge-chain.sh <option>\n" \
 		"\`$0 --verbose|-v\` \t\tset the bash script to verbose mode.  Great for troubleshooting.\n" \
-		"\`$0 --chain-name NAME\` \tsets the name of the chain; i.e. dbc-mainchain\n" \
+		"\`$0 --chain-name NAME\` \tsets the name of the chain; Ommiting this option will autoscan for any chains.\n" \
 		"\`$0 -V\` \t\t\tdisplays the script version.\n"
 }
 
 purge_chain() {
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		OS_CHAIN_DIR="$HOME/.local/share/"
-		echo -e "$OSTYPE detected!  Setting OS_CHAIN_DIR=$OS_CHAIN_DIR"
+		echo -e "$OSTYPE detected!  Setting the OS chain directory to $OS_CHAIN_DIR"
 	elif [[ "$OSTYPE" == "darwin"* ]]; then
-		echo -e "$OSTYPE detected!"
+		echo -e "$OSTYPE detected!  Setting the OS chain directory to $OS_CHAIN_DIR"
 		OS_CHAIN_DIR="$HOME/Library/Application Support/"
 	fi
 	if [[ -z $CHAIN_NAME ]] || [[ ! -d $OS_CHAIN_DIR$CHAIN_NAME ]]; then
 		echo -e "${COLOR_ERROR}[ERROR]: ${COLOR_WARNING}Could not find an executable for the chain!${COLOR_DEFAULT}" \
 			"\n\t ${COLOR_INFO}Missing executable path:${COLOR_DEFAULT} $PWD/target/*" \
 			"\n\n\t ${COLOR_INFO}Possible remedies:${COLOR_DEFAULT}\n\t ------------------" \
-			"\n\t ${COLOR_INFO}Option 1)${COLOR_DEFAULT} cd ${PROJECT_ROOT};./scripts/init.sh;./scripts/build.sh;cargo build --release" \
+			"\n\t ${COLOR_INFO}Option 1)${COLOR_DEFAULT} cd ${PROJECT_ROOT};./scripts/init.sh;cargo build --release" \
 			"\n\t ${COLOR_INFO}Option 2)${COLOR_DEFAULT} Run ./purge-chain.sh --chain-name CHAINNAME\n"
 	fi
 	if [[ -d "$OS_CHAIN_DIR$CHAIN_NAME/chains" ]]; then

--- a/scripts/purge-chain.sh
+++ b/scripts/purge-chain.sh
@@ -1,63 +1,122 @@
 #!/bin/bash
-db=$1
+cat <<EOF
+For more options and help: ./purge-chain.sh --help
+Description: Purges local Substrate chains for DeepBrain Chain.
+Authors: "DeepBrain Chain Community <community@dbc.team>", "Luke Penrod <luke@dbc.team>"
+GitHub Organization: https://github.com/dbc-community
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  echo "Clearing local data from home dir: $HOME/.local/share/edgeware"
-	if [[ "$db" == "staging" ]]; then
-		rm -rf ~/.local/share/edgeware/chains/staging_testnet/
-	elif [[ "$db" == "dev" ]]; then
-		rm -rf ~/.local/share/edgeware/chains/dev/
-		rm -rf ~/.local/share/edgeware/chains/development/
-	elif [[ "$db" == "edgeware" ]]; then
-    	rm -rf ~/.local/share/edgeware/chains/edgeware/
-    	rm -rf ~/.local/share/edgeware/chains/edgeware_testnet/
-	else
-		db="all"
-	    rm -rf ~/.local/share/edgeware/chains/dev/
-	    rm -rf ~/.local/share/edgeware/chains/development/
-	    rm -rf ~/.local/share/edgeware/chains/edgeware/
-	    rm -rf ~/.local/share/edgeware/chains/edgeware_testnet/
-	    rm -rf ~/.local/share/edgeware/chains/staging_testnet/
-    	rm -rf ~/.local/share/edgeware/chains/local_testnet/
-	fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  echo "Clearing local data from home dir: $HOME/Library/Application Support/edgeware"
-	if [[ "$db" == "staging" ]]; then
-		rm -rf ~/Library/Application\ Support/edgeware/chains/staging_testnet/
-	elif [[ "$db" == "dev" ]]; then
-		rm -rf ~/Library/Application\ Support/edgeware/chains/dev/
-		rm -rf ~/Library/Application\ Support/edgeware/chains/development/
-	elif [[ "$db" == "edgeware" ]]; then
-		rm -rf ~/Library/Application\ Support/edgeware/chains/edgeware/
-		rm -rf ~/Library/Application\ Support/edgeware/chains/edgeware_testnet/
-	else
-		db="all"
-		rm -rf ~/Library/Application\ Support/edgeware/chains/dev/
-		rm -rf ~/Library/Application\ Support/edgeware/chains/development/
-	    rm -rf ~/Library/Application\ Support/edgeware/chains/edgeware/
-	    rm -rf ~/Library/Application\ Support/edgeware/chains/edgeware_testnet/
-	    rm -rf ~/Library/Application\ Support/edgeware/chains/staging_testnet/
-		rm -rf ~/Library/Application\ Support/edgeware/chains/local_testnet/
-	fi
-else
-  echo "Clearing local data from home dir: $HOME/.local/share/edgeware"
-	if [[ "$db" == "staging" ]]; then
-		rm -rf ~/.local/share/edgeware/chains/staging_testnet/
-	elif [[ "$db" == "dev" ]]; then
-		rm -rf ~/.local/share/edgeware/chains/dev/
-		rm -rf ~/.local/share/edgeware/chains/development/
-	elif [[ "$db" == "edgeware" ]]; then
-    	rm -rf ~/.local/share/edgeware/chains/edgeware/
-    	rm -rf ~/.local/share/edgeware/chains/edgeware_testnet/
-	else
-		db="all"
-	    rm -rf ~/.local/share/edgeware/chains/dev/
-	    rm -rf ~/.local/share/edgeware/chains/development/
-	    rm -rf ~/.local/share/edgeware/chains/edgeware/
-	    rm -rf ~/.local/share/edgeware/chains/edgeware_testnet/
-	    rm -rf ~/.local/share/edgeware/chains/staging_testnet/
-    	rm -rf ~/.local/share/edgeware/chains/local_testnet/
-	fi
+EOF
+
+set -e
+
+SCRIPT_VERSION="0.1.0"
+
+# * Default messages catagories *
+COLOR_DEFAULT="\033[0m"
+COLOR_ERROR="\033[91m"
+COLOR_INFO="\033[96m"
+COLOR_SUCCESS="\033[92m"
+COLOR_WARNING="\033[93m"
+
+# * Configure directories *
+PROJECT_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$PROJECT_SCRIPTS/.."
+PROJECT_ROOT=$PWD
+
+if [[ ! -f Cargo.toml ]]; then
+	echo -e "${COLOR_ERROR}Cargo.toml not found, are you in the repository folder?\nCurrent directory: $PWD${COLOR_DEFAULT}"
+	exit 1
 fi
 
-echo "Deleted $db databases"
+prompt_purge() {
+	echo -e "Would you like to purge? ${COLOR_WARNING}(WARNING! this will delete everything)${COLOR_DEFAULT} [Yes/No]: "
+	select yn in "Yes" "No"; do
+		case $yn in
+		Yes)
+			echo -e "Purging #$dirCount: ${COLOR_INFO}$dirFullPath${COLOR_DEFAULT}"
+			rm -rf $dirFullPath
+			break
+			;;
+		No) break;;
+		esac
+	done
+}
+
+find_chain_name() {
+	CHAIN_NAME_AUTO="$(find $PWD/target -maxdepth 2 -perm -111 -type f | sed 's#.*/##' | head -n 1)"
+	if [[ -n $CHAIN_NAME_AUTO ]] && [[ -n CHAIN_NAME ]]; then
+		CHAIN_NAME=$CHAIN_NAME_AUTO
+		echo -e "${COLOR_DEFAULT}Found chain executable name: ${COLOR_INFO}${CHAIN_NAME}${COLOR_DEFAULT}"
+	fi
+}
+
+print_help() {
+	echo -e "Cleans local chain specs for DeepBrain Chain.\n" \
+		"Usage ./purge-chain.sh <option>\n" \
+		"\`$0 --verbose|-v\` \t\tset the bash script to verbose mode.  Great for troubleshooting.\n" \
+		"\`$0 --chain-name NAME\` \tsets the name of the chain; i.e. dbc-mainchain\n" \
+		"\`$0 -V\` \t\t\tdisplays the script version.\n"
+}
+
+purge_chain() {
+	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+		OS_CHAIN_DIR="$HOME/.local/share/"
+		echo -e "$OSTYPE detected!  Setting OS_CHAIN_DIR=$OS_CHAIN_DIR"
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		echo -e "$OSTYPE detected!"
+		OS_CHAIN_DIR="$HOME/Library/Application Support/"
+	fi
+	if [[ -z $CHAIN_NAME ]] || [[ ! -d $OS_CHAIN_DIR$CHAIN_NAME ]]; then
+		echo -e "${COLOR_ERROR}[ERROR]: ${COLOR_WARNING}Could not find an executable for the chain!${COLOR_DEFAULT}" \
+			"\n\t ${COLOR_INFO}Missing executable path:${COLOR_DEFAULT} $PWD/target/*" \
+			"\n\n\t ${COLOR_INFO}Possible remedies:${COLOR_DEFAULT}\n\t ------------------" \
+			"\n\t ${COLOR_INFO}Option 1)${COLOR_DEFAULT} cd ${PROJECT_ROOT};./scripts/init.sh;./scripts/build.sh;cargo build --release" \
+			"\n\t ${COLOR_INFO}Option 2)${COLOR_DEFAULT} Run ./purge-chain.sh --chain-name CHAINNAME\n"
+	fi
+	if [[ -d "$OS_CHAIN_DIR$CHAIN_NAME/chains" ]]; then
+		echo -e "Listing chains inside of: ${COLOR_INFO}$OS_CHAIN_DIR$CHAIN_NAME/chains${COLOR_DEFAULT}"
+		cd $OS_CHAIN_DIR$CHAIN_NAME/chains
+		dirCount=0
+		for dir in */; do
+			dirCount=$((dirCount + 1))
+			if [[ -d "$dir" ]]; then
+				dirFullPath=$PWD/$dir
+				echo -e "Chain #$dirCount: ${COLOR_INFO}$dir${COLOR_DEFAULT}"
+				prompt_purge
+			fi
+		done
+	fi
+	return 0
+}
+
+case $1 in
+-h | --help)
+	print_help
+	exit 0
+	;;
+-v | --verbose)
+	echo "Verbose mode set -x"
+	set -x
+	find_chain_name
+	purge_chain
+	;;
+-V)
+	echo -e "${COLOR_DEFAULT}Version: ${COLOR_INFO}${SCRIPT_VERSION}${COLOR_DEFAULT}"
+	exit 0
+	;;
+--chain-name)
+	CHAIN_NAME=$2
+	echo -e "${COLOR_DEFAULT}Updated chain name to: ${COLOR_INFO}${CHAIN_NAME}${COLOR_DEFAULT}"
+	purge_chain
+	;;
+
+'')
+	find_chain_name
+	purge_chain
+	;;
+*)
+	echo "Invalid option"
+	print_help
+	exit 0
+	;;
+esac

--- a/scripts/purge-chain.sh
+++ b/scripts/purge-chain.sh
@@ -6,35 +6,33 @@ Description: Purges the local database of installed chains.
 EOF
 
 set -e
+SCRIPT_VERSION="0.1.2"
+COLOR_OPT="always"
 
-SCRIPT_VERSION="0.1.1"
+color_option() {
+	# * Test color support * #
+	totalColors="$(tput colors)"
+	if [[ $COLOR_OPT == "never" ]]; then
+		COLOR_DEFAULT="\\033[0m"
+		COLOR_ERROR="$COLOR_DEFAULT"
+		COLOR_INFO="$COLOR_DEFAULT"
+		COLOR_SUCCESS="$COLOR_DEFAULT"
+		COLOR_WARNING="$COLOR_DEFAULT"
+	fi
 
-# * Test color support * #
-totalColors="$(tput colors)"
-if test -t 1 && test -n "$totalColors" && test $totalColors -ge 8; then
-	# * Default messages catagories *
-	COLOR_DEFAULT="\033[0m"
-	COLOR_ERROR="\033[91m"
-	COLOR_INFO="\033[96m"
-	COLOR_SUCCESS="\033[92m"
-	COLOR_WARNING="\033[93m"
-else
-	COLOR_DEFAULT="\033[0m"
-	COLOR_ERROR="$COLOR_DEFAULT"
-	COLOR_INFO="$COLOR_DEFAULT"
-	COLOR_SUCCESS="$COLOR_DEFAULT"
-	COLOR_WARNING="$COLOR_DEFAULT"
-fi
-
-# * Configure directories *
-PROJECT_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$PROJECT_SCRIPTS/.."
-PROJECT_ROOT=$PWD
-
-if [[ ! -f Cargo.toml ]]; then
-	echo -e "${COLOR_ERROR}Cargo.toml not found, are you in the repository folder?\nCurrent directory: $PWD${COLOR_DEFAULT}"
-	exit 1
-fi
+	if test -t 1 && test -n "$totalColors" && test "$totalColors" -ge 8; then
+		if [[ $COLOR_OPT == "always" ]]; then
+			# * Default messages catagories *
+			COLOR_DEFAULT="\\033[0m"
+			COLOR_ERROR="\\033[91m"
+			COLOR_INFO="\\033[96m"
+			COLOR_SUCCESS="\\033[92m"
+			COLOR_WARNING="\\033[93m"
+		fi
+	fi
+	echo -e "${COLOR_SUCCESS}Selected --color=${COLOR_OPT:=always}${COLOR_DEFAULT}"
+	return
+}
 
 prompt_purge() {
 	echo -e "Would you like to purge? ${COLOR_WARNING}(WARNING! this will delete everything)${COLOR_DEFAULT} [Yes/No]: "
@@ -42,28 +40,33 @@ prompt_purge() {
 		case $yn in
 		Yes)
 			echo -e "Purging #$dirCount: ${COLOR_INFO}$dirFullPath${COLOR_DEFAULT}"
-			rm -rf $dirFullPath
+			rm -rf "$dirFullPath"
 			break
 			;;
 		No) break ;;
 		esac
 	done
+
 }
 
 find_chain_name() {
-	CHAIN_NAME_AUTO="$(find $PWD/target -maxdepth 2 -perm -111 -type f | sed 's#.*/##' | head -n 1)"
-	if [[ -n $CHAIN_NAME_AUTO ]] && [[ -n CHAIN_NAME ]]; then
+	CHAIN_NAME_AUTO="$(find "$PWD/target" -maxdepth 2 -perm -111 -type f | sed 's#.*/##' | head -n 1)"
+	echo "$PWD && $CHAIN_NAME_AUTO"
+	if [[ -n $CHAIN_NAME_AUTO ]]; then
 		CHAIN_NAME=$CHAIN_NAME_AUTO
 		echo -e "${COLOR_DEFAULT}Found chain executable name: ${COLOR_INFO}${CHAIN_NAME}${COLOR_DEFAULT}"
 	fi
+
 }
 
 print_help() {
-	echo -e "Purges the local database of installed chains.\n" \
-		"Usage ./purge-chain.sh <option>\n" \
-		"\`$0 --verbose|-v\` \t\tset the bash script to verbose mode.  Great for troubleshooting.\n" \
-		"\`$0 --chain-name NAME\` \tsets the name of the chain; Ommiting this option will autoscan for any chains.\n" \
-		"\`$0 -V\` \t\t\tdisplays the script version.\n"
+	echo -e "Purges the local database of installed chains.\\n" \
+		"Usage ./purge-chain.sh <option>\\n\\n" \
+		"\`$0 --verbose|-v\` \\tset the bash script to verbose mode.  Great for troubleshooting.\\n" \
+		"\`$0 -V\` \\t\\t\\tdisplays the script version.\\n" \
+		"\`$0 --color[=WHEN]\` \\tuse color when (auto, never) \\n" \
+		"\`$0 --chain-name NAME\` \\tsets the name of the chain; Ommiting this option will autoscan for any chains.\\n"
+
 }
 
 purge_chain() {
@@ -76,14 +79,14 @@ purge_chain() {
 	fi
 	if [[ -z $CHAIN_NAME ]] || [[ ! -d $OS_CHAIN_DIR$CHAIN_NAME ]]; then
 		echo -e "${COLOR_ERROR}[ERROR]: ${COLOR_WARNING}Could not find an executable for the chain!${COLOR_DEFAULT}" \
-			"\n\t ${COLOR_INFO}Missing executable path:${COLOR_DEFAULT} $PWD/target/*" \
-			"\n\n\t ${COLOR_INFO}Possible remedies:${COLOR_DEFAULT}\n\t ------------------" \
-			"\n\t ${COLOR_INFO}Option 1)${COLOR_DEFAULT} cd ${PROJECT_ROOT};./scripts/init.sh;cargo build --release" \
-			"\n\t ${COLOR_INFO}Option 2)${COLOR_DEFAULT} Run ./purge-chain.sh --chain-name CHAINNAME\n"
+			"\\n\\t ${COLOR_INFO}Missing executable path:${COLOR_DEFAULT} $PWD/target/*" \
+			"\\n\\n\\t ${COLOR_INFO}Possible remedies:${COLOR_DEFAULT}\\n\\t ------------------" \
+			"\\n\\t ${COLOR_INFO}Option 1)${COLOR_DEFAULT} cd ${PROJECT_ROOT};./scripts/init.sh;cargo build --release" \
+			"\\n\\t ${COLOR_INFO}Option 2)${COLOR_DEFAULT} Run ./purge-chain.sh --chain-name CHAINNAME\\n"
 	fi
 	if [[ -d "$OS_CHAIN_DIR$CHAIN_NAME/chains" ]]; then
 		echo -e "Listing chains inside of: ${COLOR_INFO}$OS_CHAIN_DIR$CHAIN_NAME/chains${COLOR_DEFAULT}"
-		cd $OS_CHAIN_DIR$CHAIN_NAME/chains
+		cd "$OS_CHAIN_DIR$CHAIN_NAME/chains" || return
 		dirCount=0
 		for dir in */; do
 			dirCount=$((dirCount + 1))
@@ -92,39 +95,71 @@ purge_chain() {
 				echo -e "Chain #$dirCount: ${COLOR_INFO}$dir${COLOR_DEFAULT}"
 				prompt_purge
 			fi
+			if [[ $dirCount -lt 2 ]]; then
+				echo -e "The directory is already purged...exiting."
+				exit 0
+			fi
 		done
 	fi
-	return 0
 }
 
-case $1 in
--h | --help)
-	print_help
-	exit 0
-	;;
--v | --verbose)
-	echo "Verbose mode set -x"
-	set -x
-	find_chain_name
-	purge_chain
-	;;
--V)
-	echo -e "${COLOR_DEFAULT}Version: ${COLOR_INFO}${SCRIPT_VERSION}${COLOR_DEFAULT}"
-	exit 0
-	;;
---chain-name)
-	CHAIN_NAME=$2
-	echo -e "${COLOR_DEFAULT}Updated chain name to: ${COLOR_INFO}${CHAIN_NAME}${COLOR_DEFAULT}"
-	purge_chain
-	;;
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
+	case "$1" in
+	-h | --help)
+		print_help
+		exit
+		;;
+	-V)
+		echo -e "${COLOR_DEFAULT}Version: ${COLOR_INFO}${SCRIPT_VERSION}${COLOR_DEFAULT}"
+		exit
+		;;
+	-v)
+		echo "Verbose mode set -x"
+		set -x
+		;;
 
-'')
-	find_chain_name
-	purge_chain
-	;;
-*)
-	echo "Invalid option"
-	print_help
-	exit 0
-	;;
-esac
+	--color)
+		if [[ "$2" == "always" ]]; then
+			COLOR_OPT="always"
+		elif [[ "$2" == "never" ]]; then
+			COLOR_OPT="never"
+		else
+			echo "--color $2 doesn't exit!  Options are always or never."
+			exit
+		fi
+		shift
+		;;
+	--chain-name)
+		CHAIN_NAME=$2
+		echo -e "${COLOR_DEFAULT}Updated chain name to: ${COLOR_INFO}${CHAIN_NAME}${COLOR_DEFAULT}"
+		color_option
+		purge_chain
+		exit
+		;;
+	"")
+		shift
+		;;
+	*)
+		echo "Invalid option"
+		print_help
+		exit 1
+		;;
+	esac
+	shift
+done
+if [[ "$1" == '--' ]]; then shift; fi
+
+# * Configure directories *
+PROJECT_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$PROJECT_SCRIPTS/.." || return
+PROJECT_ROOT=$PWD
+
+if [[ ! -f Cargo.toml ]]; then
+	echo -e "${COLOR_ERROR}Cargo.toml not found, are you in the repository folder?\\nCurrent directory: $PWD${COLOR_DEFAULT}"
+	exit 1
+fi
+
+# * Run functions * #
+color_option
+find_chain_name
+purge_chain


### PR DESCRIPTION
Hi @raykyri,

Resolves #66 by adding dynamic lookup of executable file when `purge-chain.sh` is in the `scripts/` directory.  If none are found you can pass the `./puge-chain.sh --chain-name NAME` to manually set the name.  Then it will detect the operating system found and tag it.  Finally it will dive into the directory where chains are stored per the OS selection.  The end-user will be prompted to purge each entry found or ignore.

Let me know if you have any questions.

Sincerely, @DeepInThought 