### PR TITLE
runtime: disable GRANDPA finality fallback

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -453,7 +453,7 @@ parameter_types! {
 }
 
 impl pallet_finality_tracker::Trait for Runtime {
-	type OnFinalizationStalled = Grandpa;
+	type OnFinalizationStalled = ();
 	type WindowSize = WindowSize;
 	type ReportLatency = ReportLatency;
 }


### PR DESCRIPTION
The finality tracker keeps track of what the block authors perceive as their best finalized block, using this data it calculates the median finalized block across a window of 100 blocks. This is then used to trigger a forced GRANDPA authority set change if finality is behind the best by X number of blocks. The problem is that due to the current implementation the window to track finality can only be a short one (this is done on-chain), with 6s block times it means that if finality stops for 10 minutes we'd forcibly change the GRANDPA authority set (this is kind of a hard fork at the finality gadget level). This is another feature that we are currently not using in Polkadot since it has not been properly tested yet. This requires a runtime upgrade, and due to #140 I have noticed that forced changes were already enacted on the edgeware network.