### PR TITLE
Exposing the treasury reward parameters

### DIFF
--- a/modules/edge-treasury-reward/src/lib.rs
+++ b/modules/edge-treasury-reward/src/lib.rs
@@ -25,7 +25,7 @@ use sp_std::prelude::*;
 use sp_runtime::traits::{Zero};
 
 use frame_support::{decl_event, decl_module, decl_storage};
-use frame_system::{self as system};
+use frame_system::{self as system, ensure_root};
 pub type BalanceOf<T> = <<T as pallet_staking::Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
 pub trait Trait: pallet_staking::Trait + pallet_treasury::Trait + pallet_balances::Trait {
@@ -49,6 +49,20 @@ decl_module! {
 					<pallet_treasury::Module<T>>::account_id())
 				);
 			}
+		}
+
+		/// Sets the fixed treasury payout per minting interval.
+		#[weight = 5_000_000]
+		fn set_current_payout(origin, payout: BalanceOf<T>) {
+			ensure_root(origin)?;
+			<CurrentPayout<T>>::put(payout);
+		}
+
+		/// Sets the treasury minting interval.
+		#[weight = 5_000_000]
+		fn set_minting_interval(origin, interval: T::BlockNumber) {
+			ensure_root(origin)?;
+			<MintingInterval<T>>::put(interval);
 		}
 	}
 }

--- a/modules/edge-treasury-reward/src/tests.rs
+++ b/modules/edge-treasury-reward/src/tests.rs
@@ -375,3 +375,56 @@ fn basic_setup_works() {
 		assert_eq!(Balances::free_balance(treasury_address) > 0, true);
 	});
 }
+
+#[test]
+fn setting_treasury_block_reward () {
+	// Verifies initial conditions of mock
+	ExtBuilder::default().build().execute_with(|| {
+		// Initial Era and session
+		let treasury_address = Treasury::account_id();
+		System::set_block_number(1);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(1);
+		assert_eq!(Balances::free_balance(treasury_address)==9500000, true);
+		System::set_block_number(2);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(2);
+		assert_eq!(Balances::free_balance(treasury_address)==19000000, true);
+
+		<TreasuryReward>::set_current_payout(tests::Origin::system(frame_system::RawOrigin::Root),95).unwrap();
+		<TreasuryReward>::set_minting_interval(tests::Origin::system(frame_system::RawOrigin::Root),2).unwrap();
+		
+		System::set_block_number(3);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(3);
+		assert_eq!(Balances::free_balance(treasury_address)==19000000, true);
+		System::set_block_number(4);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(4);
+		assert_eq!(Balances::free_balance(treasury_address)==19000095, true);
+
+		<TreasuryReward>::set_current_payout(tests::Origin::system(frame_system::RawOrigin::Root),0).unwrap();
+
+		System::set_block_number(5);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(5);
+		assert_eq!(Balances::free_balance(treasury_address)==19000095, true);
+		System::set_block_number(6);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(6);
+		assert_eq!(Balances::free_balance(treasury_address)==19000095, true);
+
+		<TreasuryReward>::set_current_payout(tests::Origin::system(frame_system::RawOrigin::Root),105).unwrap();
+
+		System::set_block_number(7);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(7);
+		assert_eq!(Balances::free_balance(treasury_address)==19000095, true);
+		System::set_block_number(8);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(8);
+		assert_eq!(Balances::free_balance(treasury_address)==19000200, true);
+
+		<TreasuryReward>::set_minting_interval(tests::Origin::system(frame_system::RawOrigin::Root),1).unwrap();
+		<TreasuryReward>::set_current_payout(tests::Origin::system(frame_system::RawOrigin::Root),10).unwrap();
+
+		System::set_block_number(9);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(9);
+		assert_eq!(Balances::free_balance(treasury_address)==19000210, true);
+		System::set_block_number(10);
+		<TreasuryReward as OnFinalize<u64>>::on_finalize(10);
+		assert_eq!(Balances::free_balance(treasury_address)==19000220, true);
+	});
+}

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -23,8 +23,7 @@ use edgeware_runtime::{
 	AuthorityDiscoveryConfig, AuraConfig, BalancesConfig, ContractsConfig, CouncilConfig, DemocracyConfig,
 	GrandpaConfig, ImOnlineConfig, IndicesConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig,
 	SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
-	SignalingConfig, TreasuryRewardConfig, ElectionsConfig,
-	EVMConfig
+	SignalingConfig, TreasuryRewardConfig, EVMConfig
 };
 use edgeware_runtime::Block;
 use edgeware_runtime::constants::currency::*;

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -95,7 +95,7 @@ pub fn create_full<C, P, M, SC>(
 	let FullDeps {
 		client,
 		pool,
-		select_chain,
+		select_chain: _,
 		grandpa,
 	} = deps;
 	let GrandpaDeps {


### PR DESCRIPTION
+ Fixed warnings in release compilation.
+ Exposed the treasury reward structure parameters so that they could be modified through democracy.
+ Added a rust test the behaviour of the new function.
+ To check: whether the origin should be the root as I implemented it. I inferred this from other parts of the pallet logic, but I am not sure this should be applicable here.
+ To check: doing a live test: it seems the hash cannot be submitted on a --dev chain, and it needs at least a set of consensus nodes running to check this.