### PR TITLE
Fix Session Migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "evm",
  "frame-support",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -6874,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7185,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "serde",
  "serde_json",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7362,12 +7362,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "log 0.4.8",
  "rental",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7419,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
 
 [[package]]
 name = "substrate-wasmtime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "evm",
  "frame-support",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -6874,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7185,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "serde",
  "serde_json",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7362,12 +7362,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "log 0.4.8",
  "rental",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7419,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#cb1366e1df3dc29adb89fa29bf3b1dc1d90d3ab9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
 
 [[package]]
 name = "substrate-wasmtime"
@@ -8433,7 +8433,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "node-executor"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "node-primitives",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "evm",
  "frame-support",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5662,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "bytes 0.5.5",
  "derive_more",
@@ -5689,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5713,7 +5713,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5729,7 +5729,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5745,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5832,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5925,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5953,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5970,7 +5970,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6080,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "hex 0.4.2",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6115,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "bitflags",
  "bs58",
@@ -6167,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6182,7 +6182,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6222,7 +6222,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "log 0.4.8",
  "substrate-prometheus-endpoint",
@@ -6231,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6287,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6303,7 +6303,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "directories",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "env_logger",
  "fdlimit",
@@ -6403,7 +6403,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6417,7 +6417,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "bytes 0.5.5",
  "futures 0.3.5",
@@ -6439,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -6456,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6874,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7096,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7185,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -7238,7 +7238,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "serde",
  "sp-core",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7362,12 +7362,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "log 0.4.8",
  "rental",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7419,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "platforms",
 ]
@@ -7620,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7657,7 +7657,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#fc1e1a48ff2f74bec379887b7963564cecf1d6e1"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=time-travel#0b2a65531d89306e4d981b6da064e3a6cc81a2f5"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
 
 [[package]]
 name = "substrate-wasmtime"
@@ -8433,7 +8433,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "evm",
  "frame-support",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -6874,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7185,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "serde",
  "serde_json",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7362,12 +7362,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "log 0.4.8",
  "rental",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7419,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7457,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#ad8737685352af95c8e98ed41fbad3c423c0f861"
 
 [[package]]
 name = "substrate-wasmtime"
@@ -8433,7 +8433,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.3.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "adler32"
@@ -37,7 +37,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ dependencies = [
  "futures-io",
  "futures-timer 2.0.2",
  "kv-log-macro",
- "log 0.4.8",
+ "log 0.4.11",
  "memchr",
  "mio",
  "mio-uds",
@@ -358,7 +358,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "lazycell",
- "log 0.4.8",
+ "log 0.4.11",
  "peeking_take_while",
  "proc-macro2",
  "quote 1.0.7",
@@ -465,7 +465,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -555,12 +555,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
-dependencies = [
- "loom",
-]
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "c_linked_list"
@@ -579,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 dependencies = [
  "jobserver",
 ]
@@ -706,7 +703,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7871d2947441b0fdd8e2bd1ce2a2f75304f896582c0d572162d48290683c48"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "web-sys",
 ]
 
@@ -754,9 +751,9 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpuid-bool"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
@@ -779,7 +776,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli 0.20.0",
- "log 0.4.8",
+ "log 0.4.11",
  "regalloc",
  "serde",
  "smallvec 1.4.1",
@@ -819,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
 dependencies = [
  "cranelift-codegen",
- "log 0.4.8",
+ "log 0.4.11",
  "smallvec 1.4.1",
  "target-lexicon",
 ]
@@ -844,7 +841,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "log 0.4.8",
+ "log 0.4.11",
  "serde",
  "thiserror",
  "wasmparser 0.51.4",
@@ -897,12 +894,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -975,7 +972,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
  "subtle 2.2.3",
 ]
 
@@ -1017,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -1047,7 +1044,7 @@ checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -1071,7 +1068,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -1197,7 +1194,7 @@ dependencies = [
  "hex 0.3.2",
  "hex-literal",
  "jsonrpc-core",
- "log 0.4.8",
+ "log 0.4.11",
  "nix",
  "node-executor",
  "pallet-authority-discovery",
@@ -1291,7 +1288,7 @@ name = "edgeware-inspect"
 version = "3.0.0"
 dependencies = [
  "derive_more",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-api",
@@ -1347,7 +1344,7 @@ dependencies = [
  "futures 0.1.29",
  "hyper 0.12.35",
  "jsonrpc-core-client",
- "log 0.4.8",
+ "log 0.4.11",
  "sc-rpc",
 ]
 
@@ -1495,7 +1492,7 @@ checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -1506,7 +1503,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.8",
+ "log 0.4.11",
  "regex",
  "termcolor",
 ]
@@ -1528,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
+checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1610,7 +1607,7 @@ checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
 dependencies = [
  "goblin",
  "indexmap",
- "log 0.4.8",
+ "log 0.4.11",
  "scroll",
  "string-interner",
  "target-lexicon",
@@ -1635,7 +1632,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "synstructure",
 ]
 
@@ -1667,7 +1664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3937f028664bd0e13df401ba49a4567ccda587420365823242977f06609ed1"
 dependencies = [
  "env_logger",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -1679,7 +1676,7 @@ dependencies = [
  "either",
  "futures 0.3.5",
  "futures-timer 2.0.2",
- "log 0.4.8",
+ "log 0.4.11",
  "num-traits 0.2.12",
  "parity-scale-codec",
  "parking_lot 0.9.0",
@@ -1740,7 +1737,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1748,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1765,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1783,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1798,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1809,13 +1806,13 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "bitmask",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
- "log 0.4.8",
+ "log 0.4.11",
  "once_cell",
  "parity-scale-codec",
  "paste",
@@ -1834,40 +1831,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1883,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1994,7 +1991,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.9.0",
  "pin-project",
  "serde",
@@ -2028,7 +2025,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -2101,7 +2098,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "memchr",
  "pin-project",
@@ -2113,7 +2110,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "memchr",
  "pin-project",
@@ -2126,19 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log 0.4.8",
- "rustc_version",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
  "typenum",
  "version_check 0.9.2",
@@ -2241,7 +2225,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.8",
+ "log 0.4.11",
  "regex",
 ]
 
@@ -2264,7 +2248,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "plain",
  "scroll",
 ]
@@ -2281,7 +2265,7 @@ dependencies = [
  "futures 0.1.29",
  "http 0.1.21",
  "indexmap",
- "log 0.4.8",
+ "log 0.4.11",
  "slab",
  "string",
  "tokio-io",
@@ -2289,21 +2273,21 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
  "http 0.2.1",
  "indexmap",
- "log 0.4.8",
  "slab",
  "tokio 0.2.21",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2335,6 +2319,15 @@ checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
  "ahash",
  "autocfg 0.1.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+dependencies = [
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2424,7 +2417,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -2447,7 +2440,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "http 0.2.1",
 ]
 
@@ -2500,7 +2493,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log 0.4.8",
+ "log 0.4.11",
  "net2",
  "rustc_version",
  "time",
@@ -2517,25 +2510,25 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
  "itoa",
- "log 0.4.8",
  "pin-project",
  "socket2",
  "time",
  "tokio 0.2.21",
  "tower-service",
+ "tracing",
  "want 0.3.0",
 ]
 
@@ -2545,11 +2538,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.6",
- "log 0.4.8",
+ "hyper 0.13.7",
+ "log 0.4.11",
  "rustls",
  "rustls-native-certs",
  "tokio 0.2.21",
@@ -2623,16 +2616,17 @@ checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
  "autocfg 1.0.0",
+ "hashbrown 0.8.1",
 ]
 
 [[package]]
@@ -2707,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
+checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2725,7 +2719,7 @@ dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
  "jsonrpc-pubsub",
- "log 0.4.8",
+ "log 0.4.11",
  "serde",
  "serde_json",
  "tokio 0.1.22",
@@ -2740,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2764,7 +2758,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -2776,7 +2770,7 @@ dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.8",
+ "log 0.4.11",
  "net2",
  "parking_lot 0.10.2",
  "unicase 2.6.0",
@@ -2790,7 +2784,7 @@ checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-tokio-ipc",
  "parking_lot 0.10.2",
  "tokio-service",
@@ -2803,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
 dependencies = [
  "jsonrpc-core",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde",
@@ -2819,7 +2813,7 @@ dependencies = [
  "globset",
  "jsonrpc-core",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "tokio 0.1.22",
  "tokio-codec",
  "unicase 2.6.0",
@@ -2833,7 +2827,7 @@ checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "slab",
  "ws",
@@ -2861,7 +2855,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -2893,7 +2887,7 @@ checksum = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
 dependencies = [
  "fs-swap",
  "kvdb",
- "log 0.4.8",
+ "log 0.4.11",
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
@@ -2913,7 +2907,7 @@ dependencies = [
  "js-sys",
  "kvdb",
  "kvdb-memorydb",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-util-mem",
  "send_wrapper 0.3.0",
  "wasm-bindgen",
@@ -2946,9 +2940,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
 
 [[package]]
 name = "libflate"
@@ -2990,7 +2984,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057eba5432d3e740e313c6e13c9153d0cb76b4f71bfc2e5242ae5bdb7d41af67"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
@@ -3030,7 +3024,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.8",
+ "log 0.4.11",
  "multihash",
  "multistream-select",
  "parity-multiaddr 0.9.1",
@@ -3056,7 +3050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3067,7 +3061,7 @@ checksum = "3cc186d9a941fd0207cf8f08ef225a735e2d7296258f570155e525f6ee732f87"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -3079,7 +3073,7 @@ dependencies = [
  "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.8",
+ "log 0.4.11",
  "prost",
  "prost-build",
  "smallvec 1.4.1",
@@ -3093,14 +3087,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d6c1d5100973527ae70d82687465b17049c1b717a7964de38b8e65000878ff"
 dependencies = [
  "arrayvec 0.5.1",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "either",
  "fnv",
  "futures 0.3.5",
  "futures_codec 0.3.4",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.8",
+ "log 0.4.11",
  "multihash",
  "prost",
  "prost-build",
@@ -3127,7 +3121,7 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.8",
+ "log 0.4.11",
  "net2",
  "rand 0.7.3",
  "smallvec 1.4.1",
@@ -3141,12 +3135,12 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be7d913a4cd57de2013257ec73f07d77bfce390b370023e2d59083e5ca079864"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec 0.4.1",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
 ]
@@ -3161,7 +3155,7 @@ dependencies = [
  "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3181,7 +3175,7 @@ dependencies = [
  "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "void",
  "wasm-timer",
@@ -3195,7 +3189,7 @@ checksum = "ce53ff4d127cf8b39adf84dbd381ca32d49bd85788cee08e6669da2495993930"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.1",
  "void",
@@ -3214,7 +3208,7 @@ dependencies = [
  "get_if_addrs",
  "ipnet",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "socket2",
 ]
 
@@ -3239,11 +3233,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "085fbe4c05c4116c2164ab4d5a521eb6e00516c444f61b3ee9f68c7b1e53580b"
 dependencies = [
  "async-tls",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "either",
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "quicksink",
  "rustls",
  "rw-stream-sink",
@@ -3347,27 +3341,16 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls 0.1.2",
 ]
 
 [[package]]
@@ -3376,7 +3359,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.6.3",
 ]
 
 [[package]]
@@ -3442,7 +3425,7 @@ checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
 dependencies = [
  "ahash",
  "hash-db",
- "hashbrown",
+ "hashbrown 0.6.3",
  "parity-util-mem",
 ]
 
@@ -3494,7 +3477,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "miow 0.2.1",
  "net2",
  "slab",
@@ -3508,7 +3491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "slab",
 ]
@@ -3519,7 +3502,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "miow 0.3.5",
  "winapi 0.3.9",
@@ -3591,9 +3574,9 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "pin-project",
  "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
@@ -3633,7 +3616,7 @@ checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3684,7 +3667,7 @@ dependencies = [
 [[package]]
 name = "node-executor"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "node-primitives",
@@ -3701,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -3713,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3974,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3993,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4024,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4046,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4061,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4076,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4097,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4107,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4126,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4138,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4153,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4167,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "evm",
  "frame-support",
@@ -4188,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4204,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4224,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4240,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4259,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4275,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4289,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4304,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4319,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4334,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4347,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4362,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4377,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4397,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4411,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4431,18 +4414,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4456,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4473,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4488,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4506,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4519,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4533,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4568,7 +4551,7 @@ dependencies = [
  "blake2-rfc",
  "crc32fast",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "memmap",
  "parking_lot 0.10.2",
 ]
@@ -4616,7 +4599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
 dependencies = [
  "blake2 0.8.1",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "rand 0.7.3",
  "sha-1",
  "sha2 0.8.2",
@@ -4646,7 +4629,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4664,7 +4647,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "mio-named-pipes",
  "miow 0.3.5",
  "rand 0.7.3",
@@ -4696,7 +4679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.33",
+ "syn 1.0.35",
  "synstructure",
 ]
 
@@ -4830,7 +4813,7 @@ checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4847,9 +4830,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "plain"
@@ -4902,9 +4885,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "predicates"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
 dependencies = [
  "difference",
  "predicates-core",
@@ -4953,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
 ]
@@ -4969,7 +4952,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "version_check 0.9.2",
 ]
 
@@ -4981,7 +4964,7 @@ checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "syn-mid",
  "version_check 0.9.2",
 ]
@@ -5000,9 +4983,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -5042,7 +5025,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -5052,10 +5035,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
- "log 0.4.8",
+ "log 0.4.11",
  "multimap",
  "petgraph",
  "prost",
@@ -5074,7 +5057,7 @@ dependencies = [
  "itertools 0.8.2",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -5083,7 +5066,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -5100,7 +5083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 dependencies = [
  "byteorder",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-wasm",
 ]
 
@@ -5389,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
@@ -5421,7 +5404,7 @@ checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -5430,7 +5413,7 @@ version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "rustc-hash",
  "smallvec 1.4.1",
 ]
@@ -5501,7 +5484,7 @@ checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -5600,7 +5583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
  "base64 0.11.0",
- "log 0.4.8",
+ "log 0.4.11",
  "ring",
  "sct",
  "webpki",
@@ -5662,14 +5645,14 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "derive_more",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "prost",
  "prost-build",
@@ -5689,11 +5672,11 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -5713,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5729,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5745,18 +5728,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5766,7 +5749,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.5",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "names",
  "nix",
  "parity-util-mem",
@@ -5796,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5805,7 +5788,7 @@ dependencies = [
  "hex-literal",
  "kvdb",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-executor",
@@ -5832,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5840,7 +5823,7 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-db",
  "parity-scale-codec",
  "parity-util-mem",
@@ -5861,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5872,12 +5855,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-block-builder",
@@ -5903,11 +5886,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-client-api",
@@ -5925,12 +5908,12 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-wasm",
  "parking_lot 0.10.2",
@@ -5953,10 +5936,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-wasm",
  "sp-allocator",
@@ -5970,9 +5953,9 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "sc-executor-common",
  "sp-allocator",
@@ -5985,15 +5968,15 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-wasm",
  "sc-executor-common",
- "scoped-tls 1.0.0",
+ "scoped-tls",
  "sp-allocator",
  "sp-core",
  "sp-runtime-interface",
@@ -6006,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -6014,7 +5997,7 @@ dependencies = [
  "fork-tree",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "pin-project",
@@ -6044,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6052,7 +6035,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "log 0.4.8",
+ "log 0.4.11",
  "sc-finality-grandpa",
  "serde",
  "serde_json",
@@ -6061,11 +6044,11 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-util-mem",
  "parking_lot 0.10.2",
  "sc-client-api",
@@ -6080,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "hex 0.4.2",
@@ -6096,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6115,11 +6098,11 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "bitflags",
  "bs58",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "derive_more",
  "either",
  "erased-serde",
@@ -6133,7 +6116,7 @@ dependencies = [
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
- "log 0.4.8",
+ "log 0.4.11",
  "lru",
  "nohash-hasher",
  "parity-scale-codec",
@@ -6167,12 +6150,12 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
- "log 0.4.8",
+ "log 0.4.11",
  "lru",
  "sc-network",
  "sp-runtime",
@@ -6182,15 +6165,15 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "hyper 0.13.6",
+ "hyper 0.13.7",
  "hyper-rustls",
- "log 0.4.8",
+ "log 0.4.11",
  "num_cpus",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6209,11 +6192,11 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
- "log 0.4.8",
+ "log 0.4.11",
  "serde_json",
  "sp-utils",
  "wasm-timer",
@@ -6222,22 +6205,22 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-block-builder",
@@ -6263,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6271,7 +6254,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
@@ -6287,14 +6270,14 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
- "log 0.4.8",
+ "log 0.4.11",
  "serde",
  "serde_json",
  "sp-runtime",
@@ -6303,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "directories",
@@ -6314,7 +6297,7 @@ dependencies = [
  "hash-db",
  "jsonrpc-pubsub",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "netstat2",
  "parity-multiaddr 0.7.3",
  "parity-scale-codec",
@@ -6366,14 +6349,14 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "env_logger",
  "fdlimit",
  "futures 0.1.29",
  "futures 0.3.5",
  "hex-literal",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sc-block-builder",
@@ -6403,9 +6386,9 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
@@ -6417,13 +6400,13 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "pin-project",
  "rand 0.7.3",
@@ -6439,10 +6422,10 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "erased-serde",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "rustc-hash",
  "sc-telemetry",
@@ -6456,12 +6439,12 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "linked-hash-map",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-util-mem",
  "parking_lot 0.10.2",
  "serde",
@@ -6476,13 +6459,13 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "futures-diagnose",
  "intervalier",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
@@ -6529,12 +6512,6 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
-
-[[package]]
-name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -6562,7 +6539,7 @@ checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -6658,7 +6635,7 @@ checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -6791,7 +6768,7 @@ checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -6846,12 +6823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 dependencies = [
  "base64 0.11.0",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "flate2",
  "futures 0.3.5",
  "http 0.2.1",
  "httparse",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "sha1",
  "smallvec 1.4.1",
@@ -6862,10 +6839,10 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
- "log 0.4.8",
+ "log 0.4.11",
  "sp-core",
  "sp-std",
  "sp-wasm-interface",
@@ -6874,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6889,19 +6866,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6913,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -6926,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6938,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6949,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6961,10 +6938,10 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
- "log 0.4.8",
+ "log 0.4.11",
  "lru",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6977,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "serde",
  "serde_json",
@@ -6986,13 +6963,13 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
@@ -7010,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7024,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7042,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7054,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7068,7 +7045,7 @@ dependencies = [
  "impl-serde 0.3.1",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.8",
+ "log 0.4.11",
  "merlin",
  "num-traits 0.2.12",
  "parity-scale-codec",
@@ -7096,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7105,17 +7082,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7126,10 +7103,10 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "finality-grandpa",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -7142,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7152,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7164,12 +7141,12 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
  "libsecp256k1",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-core",
@@ -7185,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7196,7 +7173,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7208,18 +7185,18 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7229,16 +7206,16 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "backtrace",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "serde",
  "sp-core",
@@ -7247,12 +7224,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -7269,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7284,19 +7261,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7309,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "serde",
  "serde_json",
@@ -7318,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7331,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7341,11 +7318,11 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
- "log 0.4.8",
+ "log 0.4.11",
  "num-traits 0.2.12",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -7362,12 +7339,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7379,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7393,9 +7370,9 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "rental",
  "tracing",
 ]
@@ -7403,11 +7380,11 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -7419,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7433,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7445,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7457,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7473,9 +7450,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -7498,7 +7475,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -7546,7 +7523,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -7567,7 +7544,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -7585,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7597,7 +7574,7 @@ dependencies = [
  "js-sys",
  "kvdb-web",
  "libp2p-wasm-ext",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.6.5",
  "rand 0.7.3",
  "sc-chain-spec",
@@ -7612,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "platforms",
 ]
@@ -7620,14 +7597,14 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "log 0.4.8",
+ "log 0.4.11",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -7643,13 +7620,13 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.6",
- "log 0.4.8",
+ "hyper 0.13.7",
+ "log 0.4.11",
  "prometheus",
  "tokio 0.2.21",
 ]
@@ -7657,7 +7634,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7679,14 +7656,14 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "cfg-if",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "log 0.4.8",
+ "log 0.4.11",
  "memory-db",
  "pallet-babe",
  "pallet-timestamp",
@@ -7719,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc3"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#82cb61be28d957f0c4aa3fe7ee58757a372c17a8"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7740,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#59836153bcd12a15307e6a0a1d2797d680ce12f9"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=apopiak-fix-session-migration#887b440c9fde5060c168aa93bb87a823d4fe1016"
 
 [[package]]
 name = "substrate-wasmtime"
@@ -7779,7 +7756,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.20.0",
- "log 0.4.8",
+ "log 0.4.11",
  "more-asserts",
  "region",
  "substrate-wasmtime-profiling",
@@ -7856,9 +7833,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7873,7 +7850,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -7893,7 +7870,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "unicode-xid 0.2.1",
 ]
 
@@ -7973,7 +7950,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -8075,7 +8052,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -8163,7 +8140,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -8188,7 +8165,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -8265,7 +8242,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "num_cpus",
  "slab",
  "tokio-executor 0.1.10",
@@ -8302,7 +8279,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "tokio-codec",
  "tokio-io",
@@ -8319,7 +8296,7 @@ dependencies = [
  "futures 0.1.29",
  "iovec",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "mio-uds",
  "tokio-codec",
@@ -8333,10 +8310,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.8",
+ "log 0.4.11",
  "pin-project-lite",
  "tokio 0.2.21",
 ]
@@ -8358,31 +8335,32 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 dependencies = [
  "cfg-if",
+ "log 0.4.11",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 dependencies = [
  "lazy_static",
 ]
@@ -8406,8 +8384,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
 dependencies = [
  "hash-db",
- "hashbrown",
- "log 0.4.8",
+ "hashbrown 0.6.3",
+ "log 0.4.11",
  "rustc-hex",
  "smallvec 1.4.1",
 ]
@@ -8423,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twox-hash"
@@ -8526,7 +8504,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
  "subtle 2.2.3",
 ]
 
@@ -8536,7 +8514,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-io",
  "futures-util",
  "futures_codec 0.3.4",
@@ -8548,7 +8526,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures_codec 0.4.1",
 ]
 
@@ -8660,7 +8638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -8670,7 +8648,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -8682,9 +8660,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
+checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8692,24 +8670,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
+checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
+checksum = "41ad6e4e8b2b7f8c90b6e09a9b590ea15cb0d1dbe28502b5a405cd95d1981671"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8719,9 +8697,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
+checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -8729,22 +8707,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
+checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.64"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
+checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
 
 [[package]]
 name = "wasm-timer"
@@ -8831,7 +8809,7 @@ dependencies = [
  "file-per-thread-logger",
  "indexmap",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "more-asserts",
  "rayon",
  "serde",
@@ -8863,9 +8841,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
+checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9001,7 +8979,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "httparse",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "mio-extras",
  "rand 0.7.3",
@@ -9038,7 +9016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
 dependencies = [
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "nohash-hasher",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -9062,7 +9040,7 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.35",
  "synstructure",
 ]
 

--- a/modules/edge-signaling/Cargo.toml
+++ b/modules/edge-signaling/Cargo.toml
@@ -9,16 +9,16 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 voting = { package ="edge-voting", path = "../edge-voting", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [features]
 default = ["std"]

--- a/modules/edge-treasury-reward/Cargo.toml
+++ b/modules/edge-treasury-reward/Cargo.toml
@@ -8,21 +8,21 @@ edition = "2018"
 serde = { version = "1.0", default-features = false, optional = true }
 safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [features]
 default = ["std"]

--- a/modules/edge-voting/Cargo.toml
+++ b/modules/edge-voting/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 serde = { version = "1.0", default-features = false, optional = true }
 safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [features]
 default = ["std"]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -42,49 +42,49 @@ hex = "0.3.2"
 serde_json = "1.0"
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-finality-tracker = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-inherents = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sp-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-finality-tracker = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-inherents = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 # client dependencies
-sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-chain-spec = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-network = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-client-db = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sc-offchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-basic-authorship = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sc-tracing = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-telemetry = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-chain-spec = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-network = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-client-db = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sc-offchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-basic-authorship = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sc-tracing = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-telemetry = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 
 # frame dependencies
-pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-im-online = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-system-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-im-online = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-system-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 # node-specific dependencies
 edgeware-runtime = { path = "../runtime" }
@@ -94,23 +94,23 @@ edgeware-executor = { path = "../executor" }
 
 # CLI-specific dependencies
 edgeware-inspect = { version = "3.0.0", optional = true, path = "../inspect" }
-sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true }
-frame-benchmarking-cli = { optional = true, git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true }
+frame-benchmarking-cli = { optional = true, git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 
 # WASM-specific dependencies
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "substrate-browser-utils", git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true }
+browser-utils = { package = "substrate-browser-utils", git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true }
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-node-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", features = [ "wasmtime" ] }
-sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true, features = [ "wasmtime" ] }
-sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false, features = [ "wasmtime" ] }
+node-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", features = [ "wasmtime" ] }
+sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true, features = [ "wasmtime" ] }
+sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false, features = [ "wasmtime" ] }
 
 [dev-dependencies]
-sc-keystore = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-service-test = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-keystore = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-service-test = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 futures = "0.3.4"
 tempfile = "3.1.0"
 assert_cmd = "1.0"
@@ -120,11 +120,11 @@ regex = "1"
 platforms = "0.2.1"
 
 [build-dependencies]
-sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true }
-substrate-build-script-utils = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true }
+sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true }
+substrate-build-script-utils = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true }
 structopt = { version = "0.3.8", optional = true }
 edgeware-inspect = { version = "3.0.0", optional = true, path = "../inspect" }
-frame-benchmarking-cli = { optional = true, git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+frame-benchmarking-cli = { optional = true, git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 
 [features]

--- a/node/executor/Cargo.toml
+++ b/node/executor/Cargo.toml
@@ -8,30 +8,30 @@ edition = "2018"
 [dependencies]
 trie-root = "0.16.0"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-state-machine = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-trie = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-benchmarking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-state-machine = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-trie = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-benchmarking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 edgeware-primitives = { path = "../primitives" }
 edgeware-runtime = { path = "../runtime" }
 edgeware-runtime-interface = { path = "../runtime-interface" }
 
 [dev-dependencies]
-test-client = { package = "substrate-test-client", git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+test-client = { package = "substrate-test-client", git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 wabt = "0.9.2"
 criterion = "0.3.0"
 

--- a/node/inspect/Cargo.toml
+++ b/node/inspect/Cargo.toml
@@ -11,10 +11,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 derive_more = "0.99"
 log = "0.4.8"
-sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-service = { default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-blockchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-cli = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-service = { default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-blockchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 structopt = "0.3.8"

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -9,13 +9,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-application-crypto = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-application-crypto = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 [dev-dependencies]
-sp-serializer = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sp-serializer = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 pretty_assertions = "0.6.1"
 
 [features]

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -11,4 +11,4 @@ hyper = "0.12.35"
 jsonrpc-core-client = { version = "14.0.3", features = ["http", "ws"] }
 log = "0.4.8"
 edgeware-primitives = { path = "../primitives" }
-sc-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -9,19 +9,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 jsonrpc-core = "14.0.3"
-sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-contracts-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-transaction-payment-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-substrate-frame-rpc-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-keystore = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-blockchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-finality-grandpa-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-rpc-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-block-builder = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-client-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-contracts-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-transaction-payment-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+substrate-frame-rpc-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-keystore = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-consensus = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-blockchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-finality-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-finality-grandpa-rpc = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-rpc-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-block-builder = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 edgeware-primitives = { path = "../primitives" }
 edgeware-runtime = { path = "../runtime" }

--- a/node/runtime-interface/Cargo.toml
+++ b/node/runtime-interface/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime-interface = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime-interface = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 edgeware-primitives = { path = "../primitives" }
 
 [features]

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -20,61 +20,61 @@ serde = { version = "1.0.102", optional = true }
 static_assertions = "1.1.0"
 
 # primitives
-sp-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-block-builder = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false}
-sp-inherents = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", optional = true }
-sp-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-version = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-sp-offchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+sp-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-consensus-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-block-builder = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false}
+sp-inherents = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", optional = true }
+sp-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-transaction-pool = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-version = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+sp-offchain = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 # edgeware primitives
 edgeware-primitives = { path = "../primitives", default-features = false }
 
 # pallet dependencies
-pallet-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-authorship = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-collective = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-contracts-primitives = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-democracy = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-evm = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-executive = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-finality-tracker = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-identity = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-im-online = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-multisig = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-offences = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-proxy = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-recovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-scheduler = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false, features = ["historical"] }
-pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-sudo = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-utility = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
-pallet-vesting = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-authorship = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-aura = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-collective = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-contracts-primitives = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-democracy = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-evm = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-executive = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-finality-tracker = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-identity = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-im-online = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-multisig = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-offences = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-proxy = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-recovery = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-scheduler = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false, features = ["historical"] }
+pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-sudo = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-utility = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
+pallet-vesting = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", default-features = false }
 
 
 signaling = { package = "edge-signaling", path = "../../modules/edge-signaling", default-features = false }
@@ -82,10 +82,10 @@ treasury-reward = { package = "edge-treasury-reward", path = "../../modules/edge
 voting = { package = "edge-voting", path = "../../modules/edge-voting", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", version = "1.0.4" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", version = "1.0.4" }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 
 [features]
 default = ["std"]

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -103,8 +103,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 36,
-	impl_version: 36,
+	spec_version: 37,
+	impl_version: 37,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -176,7 +176,7 @@ impl frame_system::Trait for Runtime {
 	type Version = Version;
 	type ModuleToIndex = ModuleToIndex;
 	type AccountData = pallet_balances::AccountData<Balance>;
-	type MigrateAccount = (Balances, Identity, Democracy, Elections, ImOnline, Recovery, Session, Staking, Vesting);
+	type MigrateAccount = (Balances, Identity, Democracy, Elections, ImOnline, Recovery, Staking, Session, Vesting);
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -103,8 +103,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 37,
-	impl_version: 37,
+	spec_version: 38,
+	impl_version: 38,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -6,25 +6,25 @@ description = "Test utilities for Edgeware."
 edition = "2018"
 
 [dependencies]
-pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+pallet-balances = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel", features = ["test-helpers", "db"] }
-pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-sc-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-substrate-test-client = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
-pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "time-travel" }
+sc-service = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration", features = ["test-helpers", "db"] }
+pallet-contracts = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-grandpa = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-indices = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-keyring = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-session = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-staking = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+sc-executor = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+substrate-test-client = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-transaction-payment = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
+pallet-treasury = { git = "https://github.com/hicommonwealth/substrate.git", branch = "apopiak-fix-session-migration" }
 wabt = "0.9.2"
 
 edgeware-executor = { path = "../executor" }


### PR DESCRIPTION
fix session migration by:
+ moving the staking account migration before the session migration (git commit comment is wrong :grimacing:).
+ re-adding the `NextKeys` prefix migration and merging it with the hasher migration in [the companion](https://github.com/hicommonwealth/substrate/pull/17)

related to https://github.com/hicommonwealth/edgeware-node/issues/164