### PR TITLE
Upgrade frontier to pubsub.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,21 +40,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft 0.4.0",
- "aesni 0.7.0",
+ "aes-soft",
+ "aesni",
  "block-cipher",
-]
-
-[[package]]
-name = "aes-ctr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
-dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
- "ctr",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -72,17 +60,6 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-dependencies = [
- "block-cipher-trait",
- "byteorder 1.3.4",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "aes-soft"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
@@ -90,17 +67,6 @@ dependencies = [
  "block-cipher",
  "byteorder 1.3.4",
  "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "aesni"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
-dependencies = [
- "block-cipher-trait",
- "opaque-debug 0.2.3",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -253,63 +219,74 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "0.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
+checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell 1.4.1",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
+dependencies = [
+ "async-executor",
  "async-io",
  "futures-lite",
- "multitask",
- "parking 1.0.6",
- "scoped-tls",
- "waker-fn",
+ "num_cpus",
+ "once_cell 1.4.1",
 ]
 
 [[package]]
 name = "async-io"
-version = "0.1.11"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
+checksum = "33be191d05a54ec120e4667375e2ad49fe506b846463df384460ab801c7ae5dc"
 dependencies = [
- "cfg-if",
  "concurrent-queue",
+ "fastrand",
  "futures-lite",
- "libc",
+ "log 0.4.11",
+ "nb-connect",
  "once_cell 1.4.1",
- "parking 2.0.0",
+ "parking",
  "polling",
- "socket2",
  "vec-arena",
- "wepoll-sys-stjepang",
- "winapi 0.3.9",
+ "waker-fn",
 ]
 
 [[package]]
 name = "async-mutex"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66941c2577c4fa351e4ce5fdde8f86c69b88d623f3b955be1bc7362a23434632"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.6.3"
+version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
+checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
 dependencies = [
- "async-executor",
+ "async-global-executor",
  "async-io",
  "async-mutex",
- "async-task",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-lite",
- "futures-timer 3.0.2",
+ "gloo-timers",
  "kv-log-macro",
  "log 0.4.11",
  "memchr",
@@ -323,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "3.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
+checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-tls"
@@ -584,15 +561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,12 +577,13 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
+checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
 dependencies = [
  "async-channel",
  "atomic-waker",
+ "fastrand",
  "futures-lite",
  "once_cell 1.4.1",
  "waker-fn",
@@ -708,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 dependencies = [
  "jobserver",
 ]
@@ -755,15 +724,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+checksum = "d021fddb7bd3e734370acfa4a83f34095571d8570c039f1420d77540f68d5772"
 dependencies = [
  "js-sys",
+ "libc",
  "num-integer",
  "num-traits",
  "time",
  "wasm-bindgen",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1150,22 +1121,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ctr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
-dependencies = [
- "block-cipher-trait",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -1320,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.0.0",
  "ed25519",
@@ -1406,8 +1367,8 @@ dependencies = [
  "futures 0.3.5",
  "hex 0.3.2",
  "hex-literal 0.2.1",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "log 0.4.11",
  "nix",
  "pallet-authority-discovery",
@@ -1532,8 +1493,8 @@ dependencies = [
  "edgeware-runtime",
  "frontier-rpc",
  "frontier-rpc-primitives",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "pallet-contracts-rpc",
  "pallet-ethereum 0.1.0",
  "pallet-transaction-payment-rpc",
@@ -1560,7 +1521,7 @@ dependencies = [
  "env_logger",
  "futures 0.1.29",
  "hyper 0.12.35",
- "jsonrpc-core-client",
+ "jsonrpc-core-client 15.0.0",
  "log 0.4.11",
  "sc-rpc",
 ]
@@ -1680,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enumflags2"
@@ -1797,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
@@ -1985,7 +1946,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1993,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2011,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -2029,12 +1990,13 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "serde",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -2044,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2055,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -2080,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -2091,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2103,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2113,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2129,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2177,16 +2139,21 @@ dependencies = [
  "frontier-rpc-core",
  "frontier-rpc-primitives",
  "futures 0.3.5",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 14.2.0",
+ "jsonrpc-derive 14.2.2",
+ "jsonrpc-pubsub 15.0.0",
+ "log 0.4.11",
  "pallet-ethereum 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "rlp",
  "sc-client-api",
+ "sc-network",
+ "sc-rpc",
  "sc-service",
  "sha3 0.8.2",
  "sp-api",
+ "sp-blockchain",
  "sp-consensus",
  "sp-io",
  "sp-runtime",
@@ -2199,10 +2166,10 @@ name = "frontier-rpc-core"
 version = "0.1.0"
 dependencies = [
  "ethereum-types",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 14.2.0",
+ "jsonrpc-derive 14.2.2",
+ "jsonrpc-pubsub 15.0.0",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -2354,15 +2321,15 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "0.1.11"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97999970129b808f0ccba93211201d431fcc12d7e1ffae03a61b5cedd1a7ced2"
+checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
- "parking 2.0.0",
+ "parking",
  "pin-project-lite",
  "waker-fn",
 ]
@@ -2668,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
@@ -2683,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -2805,6 +2772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
+checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2876,10 +2849,10 @@ dependencies = [
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project",
  "socket2",
- "time",
  "tokio 0.2.22",
  "tower-service",
  "tracing",
@@ -2895,7 +2868,7 @@ dependencies = [
  "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.7",
+ "hyper 0.13.8",
  "log 0.4.11",
  "rustls",
  "rustls-native-certs",
@@ -2971,15 +2944,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.9.0",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "integer-sqrt"
@@ -3071,9 +3047,25 @@ checksum = "2773fa94a2a1fd51efb89a8f45b8861023dbb415d18d3c9235ae9388d780f9ec"
 dependencies = [
  "failure",
  "futures 0.1.29",
+ "jsonrpc-core 14.2.0",
+ "jsonrpc-pubsub 14.2.0",
+ "log 0.4.11",
+ "serde",
+ "serde_json",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "jsonrpc-client-transports"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f7b1cdf66312002e15682a24430728bd13036c641163c016bc53fb686a7c2d"
+dependencies = [
+ "failure",
+ "futures 0.1.29",
  "hyper 0.12.35",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "log 0.4.11",
  "serde",
  "serde_json",
@@ -3096,12 +3088,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
+dependencies = [
+ "futures 0.1.29",
+ "log 0.4.11",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonrpc-core-client"
 version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
 dependencies = [
- "jsonrpc-client-transports",
+ "jsonrpc-client-transports 14.2.1",
+]
+
+[[package]]
+name = "jsonrpc-core-client"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d175ca0cf77439b5495612bf216c650807d252d665b4b70ab2eebd895a88fac1"
+dependencies = [
+ "jsonrpc-client-transports 15.0.0",
 ]
 
 [[package]]
@@ -3117,13 +3131,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-http-server"
-version = "14.2.0"
+name = "jsonrpc-derive"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
+checksum = "c2cc6ea7f785232d9ca8786a44e9fa698f92149dcdc1acc4aa1fc69c4993d79e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpc-http-server"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9996b26c0c7a59626d0ed6c5ec8bf06218e62ce1474bd2849f9b9fd38a0158c0"
 dependencies = [
  "hyper 0.12.35",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
  "net2",
@@ -3133,11 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
+checksum = "b8e8f2278fb2b277175b6e21b23e7ecf30e78daff5ee301d0a2a411d9a821a0a"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
  "parity-tokio-ipc",
@@ -3151,7 +3177,20 @@ version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 14.2.0",
+ "log 0.4.11",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "serde",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f389c5cd1f3db258a99296892c21047e21ae73ff4c0e2d39650ea86fe994b4c7"
+dependencies = [
+ "jsonrpc-core 15.0.0",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -3160,13 +3199,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
+checksum = "c623e1895d0d9110cb0ea7736cfff13191ff52335ad33b21bd5c775ea98b27af"
 dependencies = [
  "bytes 0.4.12",
  "globset",
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "lazy_static",
  "log 0.4.11",
  "tokio 0.1.22",
@@ -3176,16 +3215,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.2.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
+checksum = "436a92034d0137ab3e3c64a7a6350b428f31cb4d7d1a89f284bcdbcd98a7bc56"
 dependencies = [
- "jsonrpc-core",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-server-utils",
  "log 0.4.11",
+ "parity-ws",
  "parking_lot 0.10.2",
  "slab",
- "ws",
 ]
 
 [[package]]
@@ -3317,9 +3356,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.24.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c101edbb9c06955fd4085b77d2abc31cf3650134d77068b35c44967756ada8"
+checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
@@ -3340,7 +3379,6 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-pnet",
  "libp2p-request-response",
- "libp2p-secio",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-uds",
@@ -3357,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cea54ea4a846a7c47e4347db0fc7a4129dcb0fb57f07f57e473820edbfcbde"
+checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3401,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6174d6addc9cc5fd84af7099480774035dd1a7cdf48dd31b23dea45cf57638"
+checksum = "74029ae187f35f4b8ddf26b9779a68b340045d708528a103917cdca49a296db5"
 dependencies = [
  "flate2",
  "futures 0.3.5",
@@ -3412,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce8769cfe677a567d2677dc02a9e5be27a24acf1ff78a59cef425caae009a6a"
+checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -3423,9 +3461,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2342965ac7ea4b85f4df5288089796421f9297ba4020dc9692f4ef728590dc"
+checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -3440,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0828b4f0c76c2edc68da574e391ce981bac5316d65785cddfe8c273d4c9bd4bb"
+checksum = "ab20fcb60edebe3173bbb708c6ac3444afdf1e3152dc2866b10c4f5497f17467"
 dependencies = [
  "base64 0.11.0",
  "byteorder 1.3.4",
@@ -3466,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41efcb5b521b65d2c45432a244ce6427cdd3649228cd192f397d1fa67682aef2"
+checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -3482,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9b4ccc868863317af3f65eb241811ceadd971d133183040140f5496037e0ae"
+checksum = "cc7fa9047f8b8f544278a35c2d9d45d3b2c1785f2d86d4e1629d6edf97be3955"
 dependencies = [
  "arrayvec 0.5.1",
  "bytes 0.5.6",
@@ -3509,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fe5614c2c5af74ef5870aad0fce73c9e4707716c4ee7cdf06cf9a0376d3815"
+checksum = "3173b5a6b2f690c29ae07798d85b9441a131ac76ddae9015ef22905b623d0c69"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -3531,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9e79541e71590846f773efce1b6d0538804992ee54ff2f407e05d63a9ddc23"
+checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -3547,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beba6459d06153f5f8e23da3df1d2183798b1f457c7c9468ff99760bcbcc60b"
+checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek 2.1.0",
@@ -3569,9 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670261ef938567b614746b078e049b03b55617538a8d415071c518f97532d043"
+checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -3584,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a61dfd53d1264ddff1206e4827193efaa72bab27782dfcd63c0dec120a1875"
+checksum = "903a12e99c72dbebefea258de887982adeacc7025baa1ceb10b7fa9928f54791"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
@@ -3616,57 +3654,31 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af0de0e56a11d46c5191a61019733b5618dc955c0a36f82866bb6d5d81a7f8f"
+checksum = "9c0c9e8a4cd69d97e9646c54313d007512f411aba8c5226cfcda16df6a6e84a3"
 dependencies = [
  "async-trait",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
  "log 0.4.11",
  "lru 0.6.0",
+ "minicbor",
  "rand 0.7.3",
  "smallvec 1.4.2",
+ "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
 
 [[package]]
-name = "libp2p-secio"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b320cc0394554e8d0adca21f4efd9f8c2da4930211d92e411a19a4dfd769e"
-dependencies = [
- "aes-ctr",
- "ctr",
- "futures 0.3.5",
- "hmac",
- "js-sys",
- "lazy_static",
- "libp2p-core",
- "log 0.4.11",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.8.2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "libp2p-swarm"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e4a7e64156e9d1a2daae36b5d791f057b9c53c9364a8e75f7f9848b54f9d68"
+checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
 dependencies = [
+ "either",
  "futures 0.3.5",
  "libp2p-core",
  "log 0.4.11",
@@ -3678,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f65400ccfbbf9a356733bceca6c519c9db0deb5fbcc0b81f89837c4cd53997"
+checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -3694,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95bc8b0ca1dda4cccb1bb156d47a32e45cfa447ef18f737209f014a63f94a4a2"
+checksum = "dea7acb0a034f70d7db94c300eba3f65c0f6298820105624088a9609c9974d77"
 dependencies = [
  "async-std",
  "futures 0.3.5",
@@ -3706,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2f7b06d80d036ac5763a811185b7fe6951ad71c00544b17cc378a9069bb7c2"
+checksum = "34c1faac6f92c21fbe155417957863ea822fba9e9fd5eb24c0912336a100e63f"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
@@ -3720,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b350db65cf0a7c83a539a596ea261caae1552c0df2245df0f916ed2fd04572"
+checksum = "d650534ebd99f48f6fa292ed5db10d30df2444943afde4407ceeddab8e513fca"
 dependencies = [
  "async-tls",
  "either",
@@ -3740,13 +3752,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3969ead4ce530efb6f304623924245caf410f3b0b0139bd7007f205933788aa"
+checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "thiserror",
  "yamux",
 ]
@@ -3942,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -3985,6 +3997,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 dependencies = [
  "log 0.3.9",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc03ad6f8f548db7194a5ff5a6f96342ecae4e3ef67d2bf18bacc0e245cd041"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c214bf3d90099b52f3e4b328ae0fe34837fd0fab683ad1e10fceb4629106df48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4115,17 +4147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multitask"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
-]
-
-[[package]]
 name = "nalgebra"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,6 +4188,16 @@ dependencies = [
  "security-framework 0.4.4",
  "security-framework-sys 0.4.3",
  "tempfile",
+]
+
+[[package]]
+name = "nb-connect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847c76b390f44529c2071ef06d0b52fbb4bdb04cc8987a5cfa63954c000abca"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4385,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4404,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4420,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4435,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4460,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4474,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4489,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "bitflags",
  "frame-support",
@@ -4510,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4520,11 +4551,11 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 15.0.0",
+ "jsonrpc-derive 15.0.0",
  "pallet-contracts-primitives",
  "pallet-contracts-rpc-runtime-api",
  "parity-scale-codec",
@@ -4539,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4551,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4566,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4611,7 +4642,7 @@ checksum = "bd4556fb64842e71bb6e2f98b7541c0d310069eb607d432c6ac9bdaecbfd3118"
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "evm",
  "frame-support",
@@ -4634,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4650,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4672,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4688,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4707,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4723,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4738,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4753,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4768,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4781,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4796,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4811,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4831,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4851,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4862,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4876,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4893,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4910,11 +4941,11 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 15.0.0",
+ "jsonrpc-derive 15.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
@@ -4928,7 +4959,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4941,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4955,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4970,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5097,10 +5128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
-name = "parking"
-version = "1.0.6"
+name = "parity-ws"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
+checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
+dependencies = [
+ "byteorder 1.3.4",
+ "bytes 0.4.12",
+ "httparse",
+ "log 0.4.11",
+ "mio",
+ "mio-extras",
+ "rand 0.7.3",
+ "sha-1 0.8.2",
+ "slab",
+ "url 2.1.1",
+]
 
 [[package]]
 name = "parking"
@@ -5267,18 +5310,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5287,9 +5330,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+checksum = "4fe74897791e156a0cd8cce0db31b9b2198e67877316bf3086c3acd187f719f0"
 
 [[package]]
 name = "pin-utils"
@@ -5323,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "0.1.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fffa183f6bd5f1a8a3e1f60ce2f8d5621e350eed84a62d6daaa5b9d1aaf6fbd"
+checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5457,9 +5500,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
@@ -5797,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -5915,27 +5958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rental"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "retain_mut"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5969,9 +5991,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
 dependencies = [
  "rustc-hex",
 ]
@@ -6135,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
@@ -6163,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6187,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6204,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6221,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6232,14 +6254,13 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "bip39",
  "chrono",
  "derive_more",
- "env_logger",
  "fdlimit",
  "futures 0.3.5",
  "hex 0.4.2",
@@ -6274,12 +6295,15 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "time",
  "tokio 0.2.22",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "fnv",
@@ -6315,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6345,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6356,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6387,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6410,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6438,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "log 0.4.11",
@@ -6455,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6470,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6488,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6525,21 +6549,23 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "futures 0.3.5",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 15.0.0",
+ "jsonrpc-derive 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "log 0.4.11",
  "parity-scale-codec",
+ "sc-client-api",
  "sc-finality-grandpa",
  "sc-rpc",
  "serde",
  "serde_json",
+ "sp-blockchain",
  "sp-core",
  "sp-runtime",
 ]
@@ -6547,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6565,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "hex 0.4.2",
@@ -6581,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6600,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6654,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6669,13 +6695,13 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures-timer 3.0.2",
- "hyper 0.13.7",
+ "hyper 0.13.8",
  "hyper-rustls",
  "log 0.4.11",
  "num_cpus",
@@ -6696,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6709,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -6718,12 +6744,12 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6750,14 +6776,14 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 15.0.0",
+ "jsonrpc-derive 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "log 0.4.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6774,23 +6800,25 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
- "jsonrpc-core",
+ "futures 0.1.29",
+ "jsonrpc-core 15.0.0",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
- "jsonrpc-pubsub",
+ "jsonrpc-pubsub 15.0.0",
  "jsonrpc-ws-server",
  "log 0.4.11",
  "serde",
  "serde_json",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "directories",
@@ -6799,8 +6827,8 @@ dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "hash-db",
- "jsonrpc-core",
- "jsonrpc-pubsub",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-pubsub 15.0.0",
  "lazy_static",
  "log 0.4.11",
  "parity-scale-codec",
@@ -6838,6 +6866,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-trie",
  "sp-utils",
@@ -6851,9 +6880,8 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
- "env_logger",
  "fdlimit",
  "futures 0.1.29",
  "futures 0.3.5",
@@ -6877,6 +6905,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-trie",
  "substrate-test-runtime",
@@ -6888,7 +6917,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6902,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6923,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -6935,13 +6964,14 @@ dependencies = [
  "slog",
  "sp-tracing",
  "tracing",
+ "tracing-core",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6962,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7410,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "log 0.4.11",
@@ -7422,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7437,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7449,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7461,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7474,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7486,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7497,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7509,7 +7539,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "log 0.4.11",
@@ -7526,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "serde",
  "serde_json",
@@ -7535,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7561,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7575,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7594,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7603,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7615,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7659,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7668,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7678,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7689,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -7705,7 +7735,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7715,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7727,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7743,12 +7773,14 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7759,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7771,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7782,7 +7814,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7792,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -7801,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "serde",
  "sp-core",
@@ -7810,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7832,7 +7864,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7848,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7860,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7873,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "serde",
  "serde_json",
@@ -7882,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7895,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7905,10 +7937,9 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "hash-db",
- "itertools 0.9.0",
  "log 0.4.11",
  "num-traits",
  "parity-scale-codec",
@@ -7918,6 +7949,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
+ "sp-std",
  "sp-trie",
  "trie-db",
  "trie-root",
@@ -7926,12 +7958,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7944,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7958,17 +7990,20 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "log 0.4.11",
- "rental",
+ "parity-scale-codec",
+ "sp-std",
  "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7983,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7997,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -8009,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8021,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8091,9 +8126,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
+checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
 dependencies = [
  "clap",
  "lazy_static",
@@ -8102,9 +8137,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
+checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -8150,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "substrate-browser-utils"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -8176,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "platforms",
 ]
@@ -8184,13 +8219,13 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpc-core 15.0.0",
+ "jsonrpc-core-client 15.0.0",
+ "jsonrpc-derive 15.0.0",
  "log 0.4.11",
  "parity-scale-codec",
  "sc-client-api",
@@ -8207,12 +8242,12 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.7",
+ "hyper 0.13.8",
  "log 0.4.11",
  "prometheus",
  "tokio 0.2.22",
@@ -8221,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8247,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -8268,6 +8303,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-core",
+ "sp-externalities",
  "sp-finality-grandpa",
  "sp-inherents",
  "sp-io",
@@ -8276,6 +8312,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "sp-session",
+ "sp-state-machine",
  "sp-std",
  "sp-transaction-pool",
  "sp-trie",
@@ -8287,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -8308,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#50c1820b856ae6d934b281da5f1eda3c6bdaba40"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7314ddce65d6023ccb7ae18006a4ada792604bfd"
 
 [[package]]
 name = "subtle"
@@ -8324,9 +8361,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8792,12 +8829,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
  "log 0.4.11",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -8815,9 +8853,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -8903,17 +8941,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "twofish"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
-dependencies = [
- "block-cipher-trait",
- "byteorder 1.3.4",
- "opaque-debug 0.2.3",
-]
 
 [[package]]
 name = "twox-hash"
@@ -9029,6 +9056,10 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+dependencies = [
+ "futures-io",
+ "futures-util",
+]
 
 [[package]]
 name = "untrusted"
@@ -9066,9 +9097,9 @@ checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec-arena"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb18268690309760d59ee1a9b21132c126ba384f374c59a94db4bc03adeb561"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -9607,24 +9638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "ws"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
-dependencies = [
- "byteorder 1.3.4",
- "bytes 0.4.12",
- "httparse",
- "log 0.4.11",
- "mio",
- "mio-extras",
- "rand 0.7.3",
- "sha-1 0.8.2",
- "slab",
- "url 2.1.1",
-]
-
-[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9647,32 +9660,32 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.4.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053585b18bca1a3d00e4b5ef93e72d4f49a10005374c455db7177e27149c899d"
+checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
  "futures 0.3.5",
  "log 0.4.11",
  "nohash-hasher",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rand 0.7.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "sc-finality-grandpa",
  "sc-finality-grandpa-rpc",
  "sc-keystore",
+ "sc-network",
  "sc-rpc",
  "sc-rpc-api",
  "sp-api",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -32,8 +32,8 @@ codec = { package = "parity-scale-codec", version = "1.3.4" }
 serde = { version = "1.0.102", features = ["derive"] }
 futures = { version = "0.3.1", features = ["compat"] }
 hex-literal = "0.2.1"
-jsonrpc-core = "14.2.0"
-jsonrpc-pubsub = "14.2.0"
+jsonrpc-core = "15.0.0"
+jsonrpc-pubsub = "15.0.0"
 log = "0.4.8"
 rand = "0.7.2"
 structopt = { version = "0.3.8", optional = true }

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -46,32 +46,24 @@ type FullGrandpaBlockImport =
 	sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>;
 type LightClient = sc_service::TLightClient<Block, RuntimeApi, Executor>;
 
+
+
 pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponents<
 	FullClient, FullBackend, FullSelectChain,
 	sp_consensus::DefaultImportQueue<Block, FullClient>,
 	sc_transaction_pool::FullPool<Block, FullClient>,
 	(
-		impl Fn(
-			edgeware_rpc::DenyUnsafe,
-			sc_rpc::SubscriptionTaskExecutor
-		) -> edgeware_rpc::IoHandler,
-		(
-			sc_consensus_aura::AuraBlockImport<
+		sc_consensus_aura::AuraBlockImport<
+			Block,
+			FullClient,
+			FrontierBlockImport<
 				Block,
-				FullClient,
-				FrontierBlockImport<
-					Block,
-					FullGrandpaBlockImport,
-					FullClient
-				>,
-				sp_consensus_aura::ed25519::AuthorityPair
+				FullGrandpaBlockImport,
+				FullClient
 			>,
-			sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
-		),
-		(
-			sc_finality_grandpa::SharedVoterState,
-			Arc<GrandpaFinalityProofProvider<FullBackend, Block>>,
-		),
+			sp_consensus_aura::ed25519::AuthorityPair
+		>,
+		sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
 	)
 >, ServiceError> {
 	let (client, backend, keystore, task_manager) =
@@ -117,50 +109,10 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
 	)?;
 
-	let import_setup = (aura_block_import.clone(), grandpa_link);
-
-	let (rpc_extensions_builder, rpc_setup) = {
-		let (_, grandpa_link) = &import_setup;
-
-		let justification_stream = grandpa_link.justification_stream();
-		let shared_authority_set = grandpa_link.shared_authority_set().clone();
-		let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
-		let finality_proof_provider =
-			GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
-
-		let rpc_setup = (shared_voter_state.clone(), finality_proof_provider.clone());
-
-		let client = client.clone();
-		let pool = transaction_pool.clone();
-		let select_chain = select_chain.clone();
-		let is_authority = config.role.clone().is_authority();
-
-		let rpc_extensions_builder = move |deny_unsafe, subscription_executor| {
-			let deps = edgeware_rpc::FullDeps {
-				client: client.clone(),
-				pool: pool.clone(),
-				select_chain: select_chain.clone(),
-				deny_unsafe,
-				grandpa: edgeware_rpc::GrandpaDeps {
-					shared_voter_state: shared_voter_state.clone(),
-					shared_authority_set: shared_authority_set.clone(),
-					justification_stream: justification_stream.clone(),
-					subscription_executor,
-					finality_provider: finality_proof_provider.clone(),
-				},
-				is_authority: is_authority,
-			};
-
-			edgeware_rpc::create_full(deps)
-		};
-
-		(rpc_extensions_builder, rpc_setup)
-	};
-
 	Ok(sc_service::PartialComponents {
-		client, backend, task_manager, keystore, select_chain, import_queue, transaction_pool,
+		client, backend, task_manager, import_queue, keystore, select_chain, transaction_pool,
 		inherent_data_providers,
-		other: (rpc_extensions_builder, import_setup, rpc_setup)
+		other: (aura_block_import.clone(), grandpa_link,)
 	})
 }
 
@@ -188,7 +140,7 @@ pub fn new_full_base(
 	let sc_service::PartialComponents {
 		client, backend, mut task_manager, import_queue, keystore, select_chain, transaction_pool,
 		inherent_data_providers,
-		other: (rpc_extensions_builder, import_setup, rpc_setup),
+		other: (block_import, grandpa_link),
 	} = new_partial(&config)?;
 
 	let finality_proof_provider =
@@ -220,13 +172,52 @@ pub fn new_full_base(
 	let prometheus_registry = config.prometheus_registry().cloned();
 	let telemetry_connection_sinks = sc_service::TelemetryConnectionSinks::default();
 
+	let (rpc_extensions_builder, rpc_setup) = {
+		let justification_stream = grandpa_link.justification_stream();
+		let shared_authority_set = grandpa_link.shared_authority_set().clone();
+		let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
+		let finality_proof_provider =
+			GrandpaFinalityProofProvider::new_for_service(backend.clone(), client.clone());
+
+		let rpc_setup = (shared_voter_state.clone(), finality_proof_provider.clone());
+
+		let client = client.clone();
+		let pool = transaction_pool.clone();
+		let select_chain = select_chain.clone();
+		let network = network.clone();
+		let is_authority = config.role.clone().is_authority();
+		let subscription_executor = sc_rpc::SubscriptionTaskExecutor::new(task_manager.spawn_handle());
+
+		let rpc_extensions_builder = Box::new(move |deny_unsafe, _| {
+			let deps = edgeware_rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				select_chain: select_chain.clone(),
+				deny_unsafe,
+				network: network.clone(),
+				grandpa: edgeware_rpc::GrandpaDeps {
+					shared_voter_state: shared_voter_state.clone(),
+					shared_authority_set: shared_authority_set.clone(),
+					justification_stream: justification_stream.clone(),
+					subscription_executor: subscription_executor.clone(),
+					finality_provider: finality_proof_provider.clone(),
+				},
+				is_authority: is_authority,
+			};
+
+			edgeware_rpc::create_full(deps, subscription_executor.clone())
+		});
+
+		(rpc_extensions_builder, rpc_setup)
+	};
+
 	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		config,
 		backend: backend.clone(),
 		client: client.clone(),
 		keystore: keystore.clone(),
 		network: network.clone(),
-		rpc_extensions_builder: Box::new(rpc_extensions_builder),
+		rpc_extensions_builder,
 		transaction_pool: transaction_pool.clone(),
 		task_manager: &mut task_manager,
 		on_demand: None,
@@ -236,7 +227,6 @@ pub fn new_full_base(
 		system_rpc_tx,
 	})?;
 
-	let (block_import, grandpa_link) = import_setup;
 	let (shared_voter_state, finality_proof_provider) = rpc_setup;
 
 	(with_startup_data)(&block_import, &grandpa_link);

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 env_logger = "0.7.0"
 futures = "0.1.29"
 hyper = "0.12.35"
-jsonrpc-core-client = { version = "14.0.3", features = ["http", "ws"] }
+jsonrpc-core-client = { version = "15.0.0", features = ["http", "ws"] }
 log = "0.4.8"
 edgeware-primitives = { path = "../primitives" }
 sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpc-core = "14.2.0"
-jsonrpc-pubsub = "14.2.0"
+jsonrpc-core = "15.0.0"
+jsonrpc-pubsub = "15.0.0"
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -26,6 +26,7 @@ sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", bra
 sc-finality-grandpa-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 edgeware-primitives = { path = "../primitives" }
 edgeware-runtime = { path = "../runtime" }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -8,11 +8,11 @@
 
 // Edgeware is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Edgeware.  If not, see <http://www.gnu.org/licenses/>.
+// along with Edgeware.	If not, see <http://www.gnu.org/licenses/>.
 
 //! The Substrate runtime. This can be compiled with ``#[no_std]`, ready for Wasm.
 
@@ -569,12 +569,12 @@ parameter_types! {
 	pub const TipReportDepositBase: Balance = 1 * DOLLARS;
 	pub const DataDepositPerByte: Balance = 1 * CENTS;
 	pub const BountyDepositBase: Balance = 1 * DOLLARS;
-  pub const BountyDepositPayoutDelay: BlockNumber = 1 * DAYS;
-  pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
-  pub const BountyUpdatePeriod: BlockNumber = 14 * DAYS;
-  pub const MaximumReasonLength: u32 = 16384;
-  pub const BountyCuratorDeposit: Permill = Permill::from_percent(50);
-  pub const BountyValueMinimum: Balance = 5 * DOLLARS;
+	pub const BountyDepositPayoutDelay: BlockNumber = 1 * DAYS;
+	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
+	pub const BountyUpdatePeriod: BlockNumber = 14 * DAYS;
+	pub const MaximumReasonLength: u32 = 16384;
+	pub const BountyCuratorDeposit: Permill = Permill::from_percent(50);
+	pub const BountyValueMinimum: Balance = 5 * DOLLARS;
 
 }
 
@@ -598,18 +598,18 @@ impl pallet_treasury::Trait for Runtime {
 	type Event = Event;
 	type ModuleId = TreasuryModuleId;
 	type OnSlash = ();
-  type ProposalBond = ProposalBond;
-  type ProposalBondMinimum = ProposalBondMinimum;
-  type SpendPeriod = SpendPeriod;
-  type Burn = Burn;
-  type BountyDepositBase = BountyDepositBase;
-  type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
-  type BountyUpdatePeriod = BountyUpdatePeriod;
-  type BountyCuratorDeposit = BountyCuratorDeposit;
-  type BountyValueMinimum = BountyValueMinimum;
-  type MaximumReasonLength = MaximumReasonLength;
-  type BurnDestination = ();
-  type WeightInfo = ();
+	type ProposalBond = ProposalBond;
+	type ProposalBondMinimum = ProposalBondMinimum;
+	type SpendPeriod = SpendPeriod;
+	type Burn = Burn;
+	type BountyDepositBase = BountyDepositBase;
+	type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
+	type BountyUpdatePeriod = BountyUpdatePeriod;
+	type BountyCuratorDeposit = BountyCuratorDeposit;
+	type BountyValueMinimum = BountyValueMinimum;
+	type MaximumReasonLength = MaximumReasonLength;
+	type BurnDestination = ();
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -732,9 +732,9 @@ impl pallet_finality_tracker::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const BasicDeposit: Balance = 10 * DOLLARS;       // 258 bytes on-chain
-	pub const FieldDeposit: Balance = 250 * CENTS;        // 66 bytes on-chain
-	pub const SubAccountDeposit: Balance = 2 * DOLLARS;   // 53 bytes on-chain
+	pub const BasicDeposit: Balance = 10 * DOLLARS;			 // 258 bytes on-chain
+	pub const FieldDeposit: Balance = 250 * CENTS;				// 66 bytes on-chain
+	pub const SubAccountDeposit: Balance = 2 * DOLLARS;	 // 53 bytes on-chain
 	pub const MaxSubAccounts: u32 = 100;
 	pub const MaxAdditionalFields: u32 = 100;
 	pub const MaxRegistrars: u32 = 20;
@@ -895,8 +895,8 @@ impl pallet_evm::Precompiles for EdgewarePrecompiles {
 		target_gas: Option<usize>
 	) -> Option<core::result::Result<(pallet_evm::ExitSucceed, Vec<u8>, usize), pallet_evm::ExitError>> {
 		match get_precompiled_func_from_address(&address) {
-		   Some(func) => return Some(func(input, target_gas)),
-		   _ => {},
+			 Some(func) => return Some(func(input, target_gas)),
+			 _ => {},
 		};
 
 		None


### PR DESCRIPTION
Bumps the underlying frontier version, as well as the associated substrate version. Fixes in the runtime and cli to support that. Test status is same as the prior version, but we can write new tests as well for the new features.