### PR TITLE
Replace error strings with decl_error enum.

### DIFF
--- a/modules/edge-signaling/src/lib.rs
+++ b/modules/edge-signaling/src/lib.rs
@@ -96,7 +96,7 @@ decl_error! {
 		// Invalid or empty title of proposal
 		InvalidProposalTitle,
 		// Invalid or empty contents of proposal
-		InvalidProposalContents
+		InvalidProposalContents,
 		// Duplicate proposal
 		DuplicateProposal,
 		// Not the proposal author

--- a/modules/edge-signaling/src/lib.rs
+++ b/modules/edge-signaling/src/lib.rs
@@ -93,19 +93,19 @@ decl_error! {
 	pub enum Error for Module<T: Trait> {
 		/// Corresponding voting for signaling proposal not found
 		VoteRecordDoesntExist,
-		// Invalid or empty title of proposal
+		/// Invalid or empty title of proposal
 		InvalidProposalTitle,
-		// Invalid or empty contents of proposal
+		/// Invalid or empty contents of proposal
 		InvalidProposalContents,
-		// Duplicate proposal
+		/// Duplicate proposal
 		DuplicateProposal,
-		// Not the proposal author
+		/// Not the proposal author
 		NotAuthor,
-		// Proposal in wrong stage
+		/// Proposal in wrong stage
 		InvalidStage,
-		// Proposal does not exist with given hash
+		/// Proposal does not exist with given hash
 		ProposalMissing,
-		// Insufficient funds to reserve bond
+		/// Insufficient funds to reserve bond
 		InsufficientFunds,
 	}
 }

--- a/modules/edge-signaling/src/lib.rs
+++ b/modules/edge-signaling/src/lib.rs
@@ -44,6 +44,10 @@ pub struct ProposalRecord<AccountId, Moment> {
 	pub vote_id: u64,
 }
 
+pub type ProposalTitle = Vec<u8>;
+pub type ProposalContents = Vec<u8>;
+type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
 pub trait Trait: voting::Trait + pallet_balances::Trait {
 	/// The overarching event type
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -51,13 +55,58 @@ pub trait Trait: voting::Trait + pallet_balances::Trait {
 	type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 }
 
-pub type ProposalTitle = Vec<u8>;
-pub type ProposalContents = Vec<u8>;
-type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+decl_storage! {
+	trait Store for Module<T: Trait> as Signaling {
+		/// The total number of proposals created thus far.
+		pub ProposalCount get(fn proposal_count) : u32;
+		/// A list of all extant proposals.
+		pub InactiveProposals get(fn inactive_proposals): Vec<(T::Hash, T::BlockNumber)>;
+		/// A list of active proposals along with the time at which they complete.
+		pub ActiveProposals get(fn active_proposals): Vec<(T::Hash, T::BlockNumber)>;
+		/// A list of completed proposals, pending deletion
+		pub CompletedProposals get(fn completed_proposals): Vec<(T::Hash, T::BlockNumber)>;
+		/// Amount of time a proposal remains in "Voting" stage.
+		pub VotingLength get(fn voting_length) config(): T::BlockNumber;
+		/// Map for retrieving the information about any proposal from its hash.
+		pub ProposalOf get(fn proposal_of): map hasher(twox_64_concat) T::Hash => Option<ProposalRecord<T::AccountId, T::BlockNumber>>;
+		/// Registration bond
+		pub ProposalCreationBond get(fn proposal_creation_bond) config(): BalanceOf<T>;
+	}
+}
+
+decl_event!(
+	pub enum Event<T> where <T as frame_system::Trait>::Hash,
+							<T as frame_system::Trait>::AccountId,
+							<T as frame_system::Trait>::BlockNumber {
+		/// Emitted at proposal creation: (Creator, ProposalHash)
+		NewProposal(AccountId, Hash),
+		/// Emitted when commit stage begins: (ProposalHash, VoteId, CommitEndTime)
+		CommitStarted(Hash, u64, BlockNumber),
+		/// Emitted when voting begins: (ProposalHash, VoteId, VotingEndTime)
+		VotingStarted(Hash, u64, BlockNumber),
+		/// Emitted when voting is completed: (ProposalHash, VoteId, VoteResults)
+		VotingCompleted(Hash, u64),
+	}
+);
 
 decl_error! {
 	pub enum Error for Module<T: Trait> {
+		/// Corresponding voting for signaling proposal not found
 		VoteRecordDoesntExist,
+		// Invalid or empty title of proposal
+		InvalidProposalTitle,
+		// Invalid or empty contents of proposal
+		InvalidProposalContents
+		// Duplicate proposal
+		DuplicateProposal,
+		// Not the proposal author
+		NotAuthor,
+		// Proposal in wrong stage
+		InvalidStage,
+		// Proposal does not exist with given hash
+		ProposalMissing,
+		// Insufficient funds to reserve bond
+		InsufficientFunds,
 	}
 }
 
@@ -82,18 +131,18 @@ decl_module! {
 			tally_type: voting::TallyType
 		) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
-			ensure!(!title.is_empty(), "Proposal must have title");
-			ensure!(!contents.is_empty(), "Proposal must not be empty");
+			ensure!(!title.is_empty(), Error::<T>::InvalidProposalTitle);
+			ensure!(!contents.is_empty(), Error::<T>::InvalidProposalContents);
 
 			// construct hash(origin + proposal) and check existence
 			let mut buf = Vec::new();
 			buf.extend_from_slice(&_sender.encode());
 			buf.extend_from_slice(&contents.as_ref());
 			let hash = T::Hashing::hash(&buf[..]);
-			ensure!(<ProposalOf<T>>::get(hash) == None, "Proposal already exists");
+			ensure!(<ProposalOf<T>>::get(hash) == None, Error::<T>::DuplicateProposal);
 
 			// Reserve the proposal creation bond amount
-			T::Currency::reserve(&_sender, Self::proposal_creation_bond()).map_err(|_| "Not enough currency for reserve bond")?;
+			T::Currency::reserve(&_sender, Self::proposal_creation_bond()).map_err(|_| Error::<T>::InsufficientFunds)?;
 			// create a vote to go along with the proposal
 			let vote_id = <voting::Module<T>>::create_vote(
 				_sender.clone(),
@@ -125,12 +174,12 @@ decl_module! {
 		#[weight = 0]
 		pub fn advance_proposal(origin, proposal_hash: T::Hash) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
-			let record = <ProposalOf<T>>::get(&proposal_hash).ok_or("Proposal does not exist")?;
+			let record = <ProposalOf<T>>::get(&proposal_hash).ok_or(Error::<T>::ProposalMissing)?;
 
 			// only permit original author to advance
-			ensure!(record.author == _sender, "Proposal must be advanced by author");
+			ensure!(record.author == _sender, Error::<T>::NotAuthor);
 			ensure!(record.stage == VoteStage::PreVoting
-				|| record.stage == VoteStage::Commit, "Proposal not in pre-voting or commit stage");
+				|| record.stage == VoteStage::Commit, Error::<T>::InvalidStage);
 
 			// prevoting -> voting or commit
 			<voting::Module<T>>::advance_stage(record.vote_id)?;
@@ -156,7 +205,7 @@ decl_module! {
 				}
 				Ok(())
 			} else {
-				return Err(Error::<T>::VoteRecordDoesntExist)?
+				Err(Error::<T>::VoteRecordDoesntExist)?
 			}
 		}
 
@@ -228,40 +277,6 @@ decl_module! {
 			// put back singly, still_inactive, inactive proposals
 			<InactiveProposals<T>>::put(still_inactive);
 		}
-	}
-}
-
-decl_event!(
-	pub enum Event<T> where <T as frame_system::Trait>::Hash,
-							<T as frame_system::Trait>::AccountId,
-							<T as frame_system::Trait>::BlockNumber {
-		/// Emitted at proposal creation: (Creator, ProposalHash)
-		NewProposal(AccountId, Hash),
-		/// Emitted when commit stage begins: (ProposalHash, VoteId, CommitEndTime)
-		CommitStarted(Hash, u64, BlockNumber),
-		/// Emitted when voting begins: (ProposalHash, VoteId, VotingEndTime)
-		VotingStarted(Hash, u64, BlockNumber),
-		/// Emitted when voting is completed: (ProposalHash, VoteId, VoteResults)
-		VotingCompleted(Hash, u64),
-	}
-);
-
-decl_storage! {
-	trait Store for Module<T: Trait> as Signaling {
-		/// The total number of proposals created thus far.
-		pub ProposalCount get(fn proposal_count) : u32;
-		/// A list of all extant proposals.
-		pub InactiveProposals get(fn inactive_proposals): Vec<(T::Hash, T::BlockNumber)>;
-		/// A list of active proposals along with the time at which they complete.
-		pub ActiveProposals get(fn active_proposals): Vec<(T::Hash, T::BlockNumber)>;
-		/// A list of completed proposals, pending deletion
-		pub CompletedProposals get(fn completed_proposals): Vec<(T::Hash, T::BlockNumber)>;
-		/// Amount of time a proposal remains in "Voting" stage.
-		pub VotingLength get(fn voting_length) config(): T::BlockNumber;
-		/// Map for retrieving the information about any proposal from its hash.
-		pub ProposalOf get(fn proposal_of): map hasher(twox_64_concat) T::Hash => Option<ProposalRecord<T::AccountId, T::BlockNumber>>;
-		/// Registration bond
-		pub ProposalCreationBond get(fn proposal_creation_bond) config(): BalanceOf<T>;
 	}
 }
 

--- a/modules/edge-voting/src/lib.rs
+++ b/modules/edge-voting/src/lib.rs
@@ -99,9 +99,62 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 }
 
+decl_storage! {
+	trait Store for Module<T: Trait> as Voting {
+		/// The map of all vote records indexed by id
+		pub VoteRecords get(fn vote_records): map hasher(twox_64_concat) u64 => Option<VoteRecord<T::AccountId>>;
+		/// The number of vote records that have been created
+		pub VoteRecordCount get(fn vote_record_count): u64;
+	}
+}
+
+decl_event!(
+	pub enum Event<T> where <T as frame_system::Trait>::AccountId {
+		/// new vote (id, creator, type of vote)
+		VoteCreated(u64, AccountId, VoteType),
+		/// vote stage transition (id, old stage, new stage)
+		VoteAdvanced(u64, VoteStage, VoteStage),
+		/// user commits
+		VoteCommitted(u64, AccountId),
+		/// user reveals a vote
+		VoteRevealed(u64, AccountId, Vec<VoteOutcome>),
+	}
+);
+
 decl_error! {
     pub enum Error for Module<T: Trait> {
-        VoteCompleted
+			/// Vote already completed
+			VoteCompleted,
+			/// Record not found for id
+			RecordMissing,
+			/// Cannot commit because vote is not commit-reveal
+			IsNotCommitReveal,
+			/// Vote not in commit stage
+			NotCommitStage,
+			/// Commit has already been made
+			DuplicateCommit,
+			/// Vote not in voting stage
+			NotVotingStage,
+			/// Ranked choice vote is not valid
+			InvalidVote,
+			/// Multi-option/binary vote is not valid
+			InvalidOutcome,
+			/// Ranked choice vote does not rank all outcomes
+			MustRankAllOutcomes,
+			/// Vote has already been cast
+			DuplicateVote,
+			/// Must pass in secret for reveal
+			InvalidSecret,
+			/// Cannot reveal if not already committed
+			SenderNotCommitted,
+			/// Hash of reveal does not match commit
+			CommitNotMatching,
+			/// Binary votes must have exactly 2 outcomes
+			InvalidBinaryOutcomes,
+			/// Multi-option votes must have >2 outcomes
+			InvalidMultiOptionOutcomes,
+			/// Ranked choice votes must have >2 outcomes
+			InvalidRankedChoiceOutcomes,
     }
 }
 
@@ -123,11 +176,11 @@ decl_module! {
 		#[weight = 0]
 		pub fn commit(origin, vote_id: u64, commit: VoteOutcome) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
-			let mut record = <VoteRecords<T>>::get(vote_id).ok_or("Vote record does not exist")?;
-			ensure!(record.data.is_commit_reveal, "Commitments are not configured for this vote");
-			ensure!(record.data.stage == VoteStage::Commit, "Vote is not in commit stage");
+			let mut record = <VoteRecords<T>>::get(vote_id).ok_or(Error::<T>::RecordMissing)?;
+			ensure!(record.data.is_commit_reveal, Error::<T>::IsNotCommitReveal);
+			ensure!(record.data.stage == VoteStage::Commit, Error::<T>::NotCommitStage);
 			// No changing of commitments once placed
-			ensure!(!record.commitments.iter().any(|c| &c.0 == &_sender), "Duplicate commits are not allowed");
+			ensure!(!record.commitments.iter().any(|c| &c.0 == &_sender), Error::<T>::DuplicateCommit);
 
 			// Add commitment to record
 			record.commitments.push((_sender.clone(), commit));
@@ -143,32 +196,32 @@ decl_module! {
 		#[weight = 0]
 		pub fn reveal(origin, vote_id: u64, vote: Vec<VoteOutcome>, secret: Option<VoteOutcome>) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
-			let mut record = <VoteRecords<T>>::get(vote_id).ok_or("Vote record does not exist")?;
-			ensure!(record.data.stage == VoteStage::Voting, "Vote is not in voting stage");
+			let mut record = <VoteRecords<T>>::get(vote_id).ok_or(Error::<T>::RecordMissing)?;
+			ensure!(record.data.stage == VoteStage::Voting, Error::<T>::NotVotingStage);
 			// Check vote is for valid outcomes
 			if record.data.vote_type == VoteType::RankedChoice {
 				ensure!(Self::is_ranked_choice_vote_valid(
 					vote.clone(),
 					record.outcomes.clone()
-				), "Ranked choice vote invalid");
+				), Error::<T>::InvalidVote);
 			} else {
 				ensure!(Self::is_valid_vote(
 					vote.clone(),
 					record.outcomes.clone()
-				), "Vote outcome is not valid");
+				), Error::<T>::InvalidOutcome);
 			}
 			// Ensure ranked choice votes have same number of votes as outcomes
 			if record.data.vote_type == VoteType::RankedChoice {
-				ensure!(record.outcomes.len() == vote.len(), "Vote must rank all outcomes in order");
+				ensure!(record.outcomes.len() == vote.len(), Error::<T>::MustRankAllOutcomes);
 			}
 			// Reject vote or reveal changes
-			ensure!(!record.reveals.iter().any(|c| &c.0 == &_sender), "Duplicate votes are not allowed");
+			ensure!(!record.reveals.iter().any(|c| &c.0 == &_sender), Error::<T>::DuplicateVote);
 			// Ensure voter committed
 			if record.data.is_commit_reveal {
 				// Ensure secret is passed in
-				ensure!(secret.is_some(), "Secret is invalid");
+				ensure!(secret.is_some(), Error::<T>::InvalidSecret);
 				// Ensure the current sender has already committed previously
-				ensure!(record.commitments.iter().any(|c| &c.0 == &_sender), "Sender not yet committed");
+				ensure!(record.commitments.iter().any(|c| &c.0 == &_sender), Error::<T>::SenderNotCommitted);
 				let commit: (T::AccountId, VoteOutcome) = record.commitments
 					.iter()
 					.find(|c| &c.0 == &_sender)
@@ -183,7 +236,7 @@ decl_module! {
 				}
 				let hash = T::Hashing::hash_of(&buf);
 				// Ensure the hashes match
-				ensure!(hash.encode() == commit.1.encode(), "Commitments do not match");
+				ensure!(hash.encode() == commit.1.encode(), Error::<T>::CommitNotMatching);
 			}
 			// Record the revealed vote and emit an event
 			let id = record.id;
@@ -204,9 +257,9 @@ impl<T: Trait> Module<T> {
 		tally_type: TallyType,
 		outcomes: Vec<VoteOutcome>
 	) -> result::Result<u64, &'static str> {
-		if vote_type == VoteType::Binary { ensure!(outcomes.len() == 2, "Invalid binary outcomes") }
-		if vote_type == VoteType::MultiOption { ensure!(outcomes.len() > 2, "Invalid multi option outcomes") }
-		if vote_type == VoteType::RankedChoice { ensure!(outcomes.len() > 2, "Invalid ranked choice outcomes") }
+		if vote_type == VoteType::Binary { ensure!(outcomes.len() == 2, Error::<T>::InvalidBinaryOutcomes) }
+		if vote_type == VoteType::MultiOption { ensure!(outcomes.len() > 2, Error::<T>::InvalidMultiOptionOutcomes) }
+		if vote_type == VoteType::RankedChoice { ensure!(outcomes.len() > 2, Error::<T>::InvalidRankedChoiceOutcomes) }
 
 		let id = Self::vote_record_count() + 1;
 		<VoteRecords<T>>::insert(id, VoteRecord {
@@ -230,7 +283,7 @@ impl<T: Trait> Module<T> {
 
 	/// A helper function for advancing the stage of a vote, as a state machine
 	pub fn advance_stage(vote_id: u64) -> DispatchResult {
-		let mut record = <VoteRecords<T>>::get(vote_id).ok_or("Vote record does not exist")?;
+		let mut record = <VoteRecords<T>>::get(vote_id).ok_or(Error::<T>::RecordMissing)?;
 		let curr_stage = record.data.stage;
 		let next_stage = match curr_stage {
 			VoteStage::PreVoting if record.data.is_commit_reveal => VoteStage::Commit,
@@ -276,28 +329,6 @@ impl<T: Trait> Module<T> {
 
 	pub fn get_vote_record(vote_id: u64) -> Option<VoteRecord<T::AccountId>> {
 		return <VoteRecords<T>>::get(vote_id);
-	}
-}
-
-decl_event!(
-	pub enum Event<T> where <T as frame_system::Trait>::AccountId {
-		/// new vote (id, creator, type of vote)
-		VoteCreated(u64, AccountId, VoteType),
-		/// vote stage transition (id, old stage, new stage)
-		VoteAdvanced(u64, VoteStage, VoteStage),
-		/// user commits
-		VoteCommitted(u64, AccountId),
-		/// user reveals a vote
-		VoteRevealed(u64, AccountId, Vec<VoteOutcome>),
-	}
-);
-
-decl_storage! {
-	trait Store for Module<T: Trait> as Voting {
-		/// The map of all vote records indexed by id
-		pub VoteRecords get(fn vote_records): map hasher(twox_64_concat) u64 => Option<VoteRecord<T::AccountId>>;
-		/// The number of vote records that have been created
-		pub VoteRecordCount get(fn vote_record_count): u64;
 	}
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -114,8 +114,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 41,
-	impl_version: 41,
+	spec_version: 42,
+	impl_version: 42,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };


### PR DESCRIPTION
* Populates `decl_error` in `voting` and `signaling` modules and replaces all error strings with those enums.
* Updates test cases for the new errors, and adds additional tests as needed.
* Rearranged the order of the module files to match Substrate modules (first storage, then events, then errors, then module calls).