### PR TITLE
Enable commit reveal signaling proposals.

### DIFF
--- a/modules/edge-signaling/src/lib.rs
+++ b/modules/edge-signaling/src/lib.rs
@@ -79,7 +79,8 @@ decl_module! {
 			contents: ProposalContents,
 			outcomes: Vec<VoteOutcome>,
 			vote_type: voting::VoteType,
-			tally_type: voting::TallyType
+			tally_type: voting::TallyType,
+			is_commit_reveal: bool,
 		) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
 			ensure!(!title.is_empty(), "Proposal must have title");
@@ -98,7 +99,7 @@ decl_module! {
 			let vote_id = <voting::Module<T>>::create_vote(
 				_sender.clone(),
 				vote_type,
-				false, // not commit-reveal
+				is_commit_reveal,
 				tally_type,
 				outcomes,
 			)?;

--- a/modules/edge-signaling/src/lib.rs
+++ b/modules/edge-signaling/src/lib.rs
@@ -80,7 +80,7 @@ decl_module! {
 			outcomes: Vec<VoteOutcome>,
 			vote_type: voting::VoteType,
 			tally_type: voting::TallyType,
-			is_commit_reveal: bool,
+			voting_scheme: voting::VotingScheme,
 		) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
 			ensure!(!title.is_empty(), "Proposal must have title");
@@ -99,7 +99,7 @@ decl_module! {
 			let vote_id = <voting::Module<T>>::create_vote(
 				_sender.clone(),
 				vote_type,
-				is_commit_reveal,
+				voting_scheme,
 				tally_type,
 				outcomes,
 			)?;

--- a/modules/edge-signaling/src/tests.rs
+++ b/modules/edge-signaling/src/tests.rs
@@ -18,8 +18,7 @@ use super::*;
 
 use frame_support::{
 	parameter_types, impl_outer_origin, assert_err, assert_ok, weights::Weight,
-	traits::{OnFinalize}, Twox128, Blake2_256, StorageHasher,
-	storage::{unhashed, generator::StorageMap as GeneratorMap},
+	traits::{OnFinalize},
 };
 use sp_core::{H256, Blake2Hasher, Hasher};
 use sp_runtime::{
@@ -235,7 +234,7 @@ fn propose_commit_reveal_should_work() {
 		assert_ok!(propose(public, title, proposal, outcomes.clone(), VoteType::Binary, TallyType::OneCoin, VotingScheme::CommitReveal));
 		assert_err!(
 			propose(public, title, proposal, outcomes, VoteType::Binary, TallyType::OneCoin, VotingScheme::CommitReveal),
-			"Proposal already exists");
+			Error::<Test>::DuplicateProposal);
 		assert_eq!(Signaling::proposal_count(), 1);
 		assert_eq!(Signaling::inactive_proposals(), vec![(hash, 10001)]);
 		assert_eq!(
@@ -696,8 +695,6 @@ fn propose_multichoice_should_work() {
 fn change_hasher_migration() {
 	mod deprecated {
 		use sp_std::prelude::*;
-		
-		use codec::{Encode, Decode};
 		use frame_support::{decl_module, decl_storage};
 
 		use crate::{Trait, ProposalRecord};

--- a/modules/edge-voting/src/tests.rs
+++ b/modules/edge-voting/src/tests.rs
@@ -22,7 +22,6 @@ use sp_runtime::{
 use sp_core::H256;
 use frame_support::{
 	parameter_types, impl_outer_origin, assert_err, assert_ok, weights::Weight,
-	traits::{OnFinalize}
 };
 
 use super::*;
@@ -633,8 +632,6 @@ fn commit_reveal_ranked_choice_vote_should_work() {
 fn change_voting_scheme_migration() {
 	mod deprecated {
 		use sp_std::prelude::*;
-
-		use codec::{Encode, Decode};
 		use frame_support::{decl_module, decl_storage};
 
 		use crate::{Trait, OldVoteRecord};

--- a/modules/edge-voting/src/tests.rs
+++ b/modules/edge-voting/src/tests.rs
@@ -92,13 +92,13 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn create_vote(
 	who: u64,
 	vote_type: VoteType,
-	is_commit_reveal: bool,
+	voting_scheme: VotingScheme,
 	tally_type: TallyType,
 	outcomes: &[[u8; 32]]
 ) -> result::Result<u64, &'static str> {
 	Voting::create_vote(who,
 						vote_type,
-						is_commit_reveal,
+						voting_scheme,
 						tally_type,
 						outcomes.to_vec())
 }
@@ -125,36 +125,36 @@ fn get_test_key_2() -> u64 {
 	return public;		
 }
 
-fn generate_1p1v_public_binary_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 2]) {
+fn generate_1p1v_public_binary_vote() -> (VoteType, VotingScheme, TallyType, [[u8; 32]; 2]) {
 	let vote_type = VoteType::Binary;
 	let tally_type = TallyType::OnePerson;
-	let is_commit_reveal = false;
+	let voting_scheme = VotingScheme::Simple;
 	let yes_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 	let no_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
-	return (vote_type, is_commit_reveal, tally_type, [yes_outcome, no_outcome]);
+	return (vote_type, voting_scheme, tally_type, [yes_outcome, no_outcome]);
 }
 
-fn generate_1p1v_commit_reveal_binary_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 2]) {
+fn generate_1p1v_commit_reveal_binary_vote() -> (VoteType, VotingScheme, TallyType, [[u8; 32]; 2]) {
 	let vote_type = VoteType::Binary;
 	let tally_type = TallyType::OnePerson;
-	let is_commit_reveal = true;
+	let voting_scheme = VotingScheme::CommitReveal;
 	let yes_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 	let no_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
-	return (vote_type, is_commit_reveal, tally_type, [yes_outcome, no_outcome]);
+	return (vote_type, voting_scheme, tally_type, [yes_outcome, no_outcome]);
 }
 
-fn generate_1p1v_public_multi_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 4]) {
+fn generate_1p1v_public_multi_vote() -> (VoteType, VotingScheme, TallyType, [[u8; 32]; 4]) {
 	let vote_type = VoteType::MultiOption;
 	let tally_type = TallyType::OnePerson;
-	let is_commit_reveal = false;
+	let voting_scheme = VotingScheme::Simple;
 	let one_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 	let two_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2];
 	let three_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3];
 	let four_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4];
 
-	return (vote_type, is_commit_reveal, tally_type, [
+	return (vote_type, voting_scheme, tally_type, [
 		one_outcome,
 		two_outcome,
 		three_outcome,
@@ -162,16 +162,16 @@ fn generate_1p1v_public_multi_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 4
 	]);
 }
 
-fn generate_1p1v_public_ranked_choice_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 4]) {
+fn generate_1p1v_public_ranked_choice_vote() -> (VoteType, VotingScheme, TallyType, [[u8; 32]; 4]) {
 	let vote_type = VoteType::RankedChoice;
 	let tally_type = TallyType::OnePerson;
-	let is_commit_reveal = false;
+	let voting_scheme = VotingScheme::Simple;
 	let one_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 	let two_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2];
 	let three_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3];
 	let four_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4];
 
-	return (vote_type, is_commit_reveal, tally_type, [
+	return (vote_type, voting_scheme, tally_type, [
 		one_outcome,
 		two_outcome,
 		three_outcome,
@@ -179,16 +179,16 @@ fn generate_1p1v_public_ranked_choice_vote() -> (VoteType, bool, TallyType, [[u8
 	]);
 }
 
-fn generate_1p1v_commit_reveal_ranked_choice_vote() -> (VoteType, bool, TallyType, [[u8; 32]; 4]) {
+fn generate_1p1v_commit_reveal_ranked_choice_vote() -> (VoteType, VotingScheme, TallyType, [[u8; 32]; 4]) {
 	let vote_type = VoteType::RankedChoice;
 	let tally_type = TallyType::OnePerson;
-	let is_commit_reveal = true;
+	let voting_scheme = VotingScheme::CommitReveal;
 	let one_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1];
 	let two_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2];
 	let three_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3];
 	let four_outcome: [u8; 32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4];
 
-	return (vote_type, is_commit_reveal, tally_type, [
+	return (vote_type, voting_scheme, tally_type, [
 		one_outcome,
 		two_outcome,
 		three_outcome,
@@ -200,7 +200,7 @@ fn make_record(
 	id: u64,
 	author: u64,
 	vote_type: VoteType,
-	is_commit_reveal: bool,
+	voting_scheme: VotingScheme,
 	tally_type: TallyType,
 	outcomes: &[[u8; 32]],
 	stage: VoteStage
@@ -215,7 +215,7 @@ fn make_record(
 			stage: stage,
 			vote_type: vote_type,
 			tally_type: tally_type,
-			is_commit_reveal: is_commit_reveal,
+			voting_scheme: voting_scheme,
 		},
 	}
 }
@@ -421,8 +421,8 @@ fn transition_to_commit_should_work() {
 		let vote = generate_1p1v_commit_reveal_binary_vote();
 		assert_eq!(Ok(1), create_vote(public, vote.0, vote.1, vote.2, &vote.3));
 		assert_eq!(
-			Voting::vote_records(1).unwrap().data.is_commit_reveal,
-			true
+			Voting::vote_records(1).unwrap().data.voting_scheme,
+			VotingScheme::CommitReveal,
 		);
 		assert_ok!(advance_stage(1));
 		assert_eq!(
@@ -440,8 +440,8 @@ fn reveal_before_commit_should_not_work() {
 		let vote = generate_1p1v_commit_reveal_binary_vote();
 		assert_eq!(Ok(1), create_vote(public, vote.0, vote.1, vote.2, &vote.3));
 		assert_eq!(
-			Voting::vote_records(1).unwrap().data.is_commit_reveal,
-			true
+			Voting::vote_records(1).unwrap().data.voting_scheme,
+			VotingScheme::CommitReveal,
 		);
 		let public2 = get_test_key_2();
 		assert_err!(reveal(public2, 1, vec![vote.3[0]], Some(vote.3[0])), "Vote is not in voting stage");
@@ -605,7 +605,7 @@ fn change_hasher_migration() {
 				stage: VoteStage::PreVoting,
 				vote_type: VoteType::Binary,
 				tally_type: TallyType::OneCoin,
-				is_commit_reveal: false,
+				voting_scheme: VotingScheme::Simple,
 			},
 		};
 

--- a/modules/edge-voting/src/tests.rs
+++ b/modules/edge-voting/src/tests.rs
@@ -574,7 +574,7 @@ fn change_voting_scheme_migration() {
 		use codec::{Encode, Decode};
 		use frame_support::{decl_module, decl_storage};
 
-		use crate::{Trait, VoteRecord};
+		use crate::{Trait, OldVoteRecord};
 
 		decl_module! {
 			pub struct Module<T: Trait> for enum Call where origin: T::Origin { }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -114,8 +114,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 42,
-	impl_version: 42,
+	spec_version: 43,
+	impl_version: 43,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };


### PR DESCRIPTION
Adds a `VotingScheme` enum and enables submitting commit-reveal signaling proposals.

**API BREAKING CHANGE**