### PR TITLE
Upgrade CI to store binary artifact.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
       - run: apt-get update
       - run: apt-get install -y sudo git curl
       - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-      - run: apt-get update
-      - run: sudo apt-get install -y nodejs npm
+      - run: sudo apt-get install -y nodejs
       - run: npm install --global yarn
       - run: echo $(node -v)
+      - run: echo $(npm -v)
 
       # begin using repo-specific scripts
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ jobs:
     working_directory: ~/edgeware
 
     steps:
+      - run: apt-get update
+      - run: apt-get install sudo git nodejs npm
       - checkout
-      - run: sudo apt-get update
-      - run: sudo apt-get install nodejs npm
       - run: npm install --global yarn
       - run: ~/edgeware/scripts/init.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
       - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
       - run: sudo apt-get install -y nodejs
       - run: npm install --global yarn
-      - run: echo $(node -v)
-      - run: echo $(npm -v)
 
       # begin using repo-specific scripts
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:lts
+      - image: ubuntu:18.04
         environment:
           DEBUG_BUILD: true
           DEBIAN_FRONTEND: noninteractive
@@ -12,6 +12,8 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
+      - run: sudo apt-get install nodejs npm
+      - run: npm install --global yarn
       - run: ~/edgeware/scripts/init.sh
 
       # get cached edgeware build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,11 @@ jobs:
       # full build
       - run: source ~/.cargo/env && cd ~/edgeware && cargo build --release
 
+      # save the built binary
+      - store_artifacts:
+          path: ~/edgeware/target/release/edgeware
+          destination: edgeware-node
+
       # save edgeware build
       - save_cache:
           key: edgeware-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,17 @@ jobs:
     working_directory: ~/edgeware
 
     steps:
+      # basic image config to install sudo, node, yarn
       - run: apt-get update
-      - run: apt-get install -y sudo git nodejs npm
-      - checkout
+      - run: apt-get install -y sudo git curl
+      - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+      - run: apt-get update
+      - run: sudo apt-get install -y nodejs npm
       - run: npm install --global yarn
+      - run: echo "Node: $(node -v)"
+
+      # begin using repo-specific scripts
+      - checkout
       - run: ~/edgeware/scripts/init.sh
 
       # get cached edgeware build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:15.4.0
+      - image: cimg/node:lts
         environment:
           DEBUG_BUILD: true
           DEBIAN_FRONTEND: noninteractive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - run: apt-get update
-      - run: apt-get install sudo git nodejs npm
+      - run: apt-get install -y sudo git nodejs npm
       - checkout
       - run: npm install --global yarn
       - run: ~/edgeware/scripts/init.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: apt-get update
       - run: sudo apt-get install -y nodejs npm
       - run: npm install --global yarn
-      - run: echo "Node: $(node -v)"
+      - run: echo $(node -v)
 
       # begin using repo-specific scripts
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ db
 node_modules
 forker-data
 beresheet-state.json
+build

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
         SUDO_PREFIX='sudo'
     fi
     $SUDO_PREFIX apt update
-    $SUDO_PREFIX apt install -y build-essential cmake pkg-config libssl-dev openssl git clang libclang-dev
+    $SUDO_PREFIX apt install -y curl build-essential cmake pkg-config libssl-dev openssl git clang libclang-dev
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Found macbook"
     brew install cmake pkg-config openssl git llvm

--- a/ts-tests/frontier-tester/tests/testTime.js
+++ b/ts-tests/frontier-tester/tests/testTime.js
@@ -10,7 +10,7 @@ function timeout(ms) {
 }
 
 function blockTimeifyDate(n) {
-  return Math.floor(n / 1000);
+  return Math.floor(n / BLOCK_TIME_MS) * (BLOCK_TIME_MS / 1000);
 }
 
 describeWithEdgeware("TimeContract test", async (context) => {


### PR DESCRIPTION
Binary artifact will run on Ubuntu 18.04 (and hopefully later).

Please merge this with squash.