### PR TITLE
Remove bootnodes mainnet6-10 and mainnet16-20

### DIFF
--- a/chains/mainnet.json
+++ b/chains/mainnet.json
@@ -7,21 +7,11 @@
     "/ip4/66.42.113.164/tcp/30333/p2p/Qmawkfqh4y4vnPWiy87pBnWpgsyy8QrQmUFprDTktgatSm",
     "/ip4/144.202.58.79/tcp/30333/p2p/QmXWhRta7P3xW43WbJ6CDH9ZsHwVxFhLJNjpBa6J3jaAqj",
     "/ip4/207.148.13.203/tcp/30333/p2p/QmRgKnmZNYVCznVd4ao5UHCHGWieT3sePB5g8v7PSGofD2",
-    "/ip4/207.148.11.222/tcp/30333/p2p/QmbzrqjbDcwhhX1oiKndxTjK1ULjqVw36QvrEuRKSZjgLY",
-    "/ip4/149.28.120.45/tcp/30333/p2p/QmfB4F7TeUcuZZ4AMT3nvvfPVME4eWyJUUdWkXeus3AThe",
-    "/ip4/149.28.115.253/tcp/30333/p2p/QmQvAPW1bBpx5N7YJLcBhHNqANw4dxVmBTiJNeuC8FoYeR",
-    "/ip4/66.42.116.197/tcp/30333/p2p/QmU1g7NFj1cd46T69ZXig9c7Xc6RLGwjZm4Ur6d4JPBDh2",
-    "/ip4/104.207.139.151/tcp/30333/p2p/QmPuU4VY2nckAodyWXv3VyCwavk5FF9yqVWB4G1LtNf9v9",
     "/ip4/45.77.238.189/tcp/30333/p2p/QmUQNwBa3BTYEAggMqsM2o5owtG1szKGMcy4Yi5sxPEvmh",
     "/ip4/209.250.227.147/tcp/30333/p2p/QmTDGjGu9GiyZLgTFaqMFUkguer4svD3DLHyZbEePWGK2M",
     "/ip4/202.182.103.213/tcp/30333/p2p/QmekEvkhcEvsRYw47LVoYm7v1dAjh3qbt2wZK7HNydr3kq",
     "/ip4/207.148.77.158/tcp/30333/p2p/QmWF6T36iBiXdCAsb477vHyTEKTq33RTLRAcsyTiGwrqwB",
     "/ip4/140.82.54.194/tcp/30333/p2p/QmdCUnV8hK3oiKSkoL4r9W5foEVBvMQ49ATUNpgxWcCgXc",
-    "/ip4/155.138.133.37/tcp/30333/p2p/QmYrQtJXQSJkfcpKYgVXcbYMEuHP1PLgz41uy2dutipp9s",
-    "/ip4/45.32.171.175/tcp/30333/p2p/QmdC8MEhaWbngY7qHpgXvYr3bVYcXy1HFUBWVWzhQFFybV",
-    "/ip4/45.77.105.248/tcp/30333/p2p/QmPqNBGgeP4553TzxNd34GshUSHapsjykHhVcwnNrqpMLT",
-    "/ip4/144.202.19.214/tcp/30333/p2p/QmUr8uUsd7QJQnnbHbVh6hhdHKsZUS1xrNKJmb7YZEshae",
-    "/ip4/207.246.98.108/tcp/30333/p2p/QmVFxV5Ay158YiS7bkxNkAshEECDFMbqnfkizTgEfKQC7F"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
To reduce maintenance burden.

Once this change is merged, we can turn off deprecated bootnodes.

Keeping mainnet11-15 because they are geographically distributed across different zones.

Tested on a working node.