### PR TITLE
Wako Release v3.3.4

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -169,18 +169,6 @@ pub fn testnet_genesis(
 		storage: BTreeMap::new(),
 		code: vec![],
 	});
-	// account used in frontier
-	evm_accounts.insert(
-		H160::from_str("6be02d1d3665660d22ff9624b7be0551ee1ac91b")
-			.expect("internal H160 is valid; qed"),
-		pallet_evm::GenesisAccount {
-			balance: U256::from_str("0xffffffffffffffffffffffffffffffff")
-				.expect("internal U256 is valid; qed"),
-			code: Default::default(),
-			nonce: Default::default(),
-			storage: Default::default(),
-		}
-	);
 
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub use pallet_session::historical as pallet_session_historical;
 
 use evm_runtime::Config as EvmConfig;
 use fp_rpc::TransactionStatus;
-use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, FeeCalculator, HashedAddressMapping, Runner};
+use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, HashedAddressMapping, Runner};
 
 pub use sp_inherents::{CheckInherentsResult, InherentData};
 use static_assertions::const_assert;
@@ -1094,15 +1094,8 @@ impl pallet_evm::GasWeightMapping for EdgewareGasWeightMapping {
 }
 
 parameter_types! {
-	pub BlockGasLimit: U256
-		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
-}
-
-pub struct FixedGasPrice;
-impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
-		1_000_000_000.into()
-	}
+        pub BlockGasLimit: U256
+               = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
 }
 
 impl pallet_evm::Config for Runtime {
@@ -1112,7 +1105,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = EthChainId;
 	type Currency = Balances;
 	type Event = Event;
-	type FeeCalculator = FixedGasPrice;
+	type FeeCalculator = pallet_dynamic_fee::Pallet<Self>;
 	type GasWeightMapping = EdgewareGasWeightMapping;
 	type OnChargeTransaction = ();
 	type Precompiles = EdgewarePrecompiles<Self>;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -136,8 +136,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 49,
-	impl_version: 49,
+	spec_version: 50,
+	impl_version: 50,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };
@@ -151,8 +151,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 10049,
-	impl_version: 10049,
+	spec_version: 10050,
+	impl_version: 10050,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };
@@ -1074,7 +1074,7 @@ static EVM_CONFIG: EvmConfig = EvmConfig {
 
 /// Current (safe) approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM.
-pub const GAS_PER_SECOND: u64 = 8_000_000;
+pub const GAS_PER_SECOND: u64 = 150_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -1033,7 +1033,7 @@ parameter_types! {
 	pub const EthChainId: u64 = 2022;
 }
 
-/// Clone of Istanbul config with `create_contract_limit` raised.
+/// Clone of Istanbul config: https://github.com/rust-blockchain/evm/blob/master/runtime/src/lib.rs
 static EVM_CONFIG: EvmConfig = EvmConfig {
 	gas_ext_code: 700,
 	gas_ext_code_hash: 700,
@@ -1059,7 +1059,7 @@ static EVM_CONFIG: EvmConfig = EvmConfig {
 	stack_limit: 1024,
 	memory_limit: usize::max_value(),
 	call_stack_limit: 1024,
-	create_contract_limit: None,
+	create_contract_limit: Some(0x6000),
 	call_stipend: 2300,
 	has_delegate_call: true,
 	has_create2: true,

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -1074,7 +1074,11 @@ static EVM_CONFIG: EvmConfig = EvmConfig {
 
 /// Current (safe) approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM.
+#[cfg(feature = "beresheet-runtime")]
 pub const GAS_PER_SECOND: u64 = 150_000_000;
+
+#[cfg(not(feature = "beresheet-runtime"))]
+pub const GAS_PER_SECOND: u64 = 8_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to


### PR DESCRIPTION
Wako - ERUP4 Runtime Upgrade

Adjustments to maximum contract size, gas pricing, and Beresheet gas limit.

To verify this build, use the new version of srtool and srtool-cli:

```
cargo install --git https://github.com/chevdor/srtool-cli
srtool build . --package edgeware-runtime -r node/runtime
```

This should give you the results:

```
✨ Your Substrate WASM Runtime is ready! ✨
Summary generated with srtool v0.9.16 using the docker image paritytech/srtool:1.53.0:
 Package     : edgeware-runtime v3.3.3
 GIT commit  : bbc54ed8ade8b20d578f5b21311e06e4047d8dff
 GIT tag     : v3.3.3
 GIT branch  : raymond.v3.3.4
 Rustc       : rustc 1.53.0 (53cb7b09b 2021-06-17)
 Time        : 2021-09-13T21:48:27Z

== Compact
 Version     : edgeware-50 (edgeware-node-50.tx2.au16)
 Metadata    : V13
 Size        : 3.52 MB (3694868 bytes)
 Proposal    : 0xb0fe0403e6a2200c68bdcb8d339c54427c282eb479f3f56fa9f47fd95f33cbfd
 IPFS        : QmY3BZ4CWzoSWW1Jxb5pdd7d1RVdea5W25u2ALiBLUSdvz
 BLAKE2_256  : 0x0cfb0562a0b6fdf30b69b6a5b0808cbe9d33c1779ffa0192f005705771b73937
 Wasm        : node/runtime/target/srtool/release/wbuild/edgeware-runtime/edgeware_runtime.compact.wasm

== Compressed
 No compressed runtime found
```

---

Changelog:

- Remove frontier account from testnet chainspec
- Set minimum gas price and per-block gas limit
- Reset maximum contract size
- Increase gas to 150,000,000/sec for Beresheet
- Keep gas at 8,000,000/sec for Edgeware
- Bump runtime version
