### PR TITLE
Wako for Beresheet v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-cli"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "assert_cmd",
  "edgeware-executor",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-executor"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "criterion",
  "edgeware-primitives",
@@ -1606,7 +1606,7 @@ version = "0.1.0"
 
 [[package]]
 name = "edgeware-primitives"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-rpc"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "edgeware-executor",
  "edgeware-opts",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-rpc-client"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "edgeware-primitives",
  "futures 0.1.31",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-runtime"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "edge-treasury-reward",
  "edgeware-evm-tracer",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "edgeware-runtime-interface"
-version = "3.3.5"
+version = "3.3.6"
 dependencies = [
  "edgeware-primitives",
  "parity-scale-codec",

--- a/chains/README.md
+++ b/chains/README.md
@@ -1,0 +1,2 @@
+Deprecation warning: It is recommended to use the chainspecs in
+/node/cli/res instead of the (identical) ones here.

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-cli"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 description = "Edgeware implementation using a substrate node."
 build = "build.rs"
@@ -95,10 +95,10 @@ pallet-dynamic-fee = { git = "https://github.com/webb-tools/frontier", branch = 
 pallet-evm = { git = "https://github.com/webb-tools/frontier", branch = "erup-4" }
 
 # node-specific dependencies
-edgeware-runtime = { version = "3.3.5", path = "../runtime", default-features = false }
-edgeware-rpc = { version = "3.3.5", path = "../rpc" }
-edgeware-primitives = { version = "3.3.5", path = "../primitives", default-features = false }
-edgeware-executor = { version = "3.3.5", path = "../executor", default-features = false }
+edgeware-runtime = { version = "3.3.6", path = "../runtime", default-features = false }
+edgeware-rpc = { version = "3.3.6", path = "../rpc" }
+edgeware-primitives = { version = "3.3.6", path = "../primitives", default-features = false }
+edgeware-executor = { version = "3.3.6", path = "../executor", default-features = false }
 edgeware-rpc-txpool = { path = "../../client/rpc/txpool", default-features = false }
 edgeware-rpc-primitives-txpool = { path = "../txpool", default-features = false }
 edgeware-rpc-debug = { path = "../../client/rpc/debug", default-features = false }

--- a/node/cli/res/beresheetv3.chainspec.json
+++ b/node/cli/res/beresheetv3.chainspec.json
@@ -1,0 +1,89 @@
+edgeware-build-spec 3.3.5
+Build a chain specification
+
+USAGE:
+    edgeware build-spec [FLAGS] [OPTIONS]
+
+FLAGS:
+        --dev                         
+            Specify the development chain
+
+        --disable-default-bootnode    
+            Disable adding the default bootnode to the specification.
+            
+            By default the `/ip4/127.0.0.1/tcp/30333/p2p/NODE_PEER_ID` bootnode is added to the specification when no
+            bootnode exists.
+        --disable-log-color           
+            Disable log color output
+
+        --disable-log-reloading       
+            Disable feature to dynamically update and reload the log filter.
+            
+            By default this feature is enabled, however it leads to a small performance decrease. The
+            `system_addLogFilter` and `system_resetLogFilter` RPCs will have no effect with this option set.
+    -h, --help                        
+            Prints help information
+
+        --raw                         
+            Force raw genesis storage output
+
+    -V, --version                     
+            Prints version information
+
+
+OPTIONS:
+    -d, --base-path <PATH>               
+            Specify custom base path
+
+        --chain <CHAIN_SPEC>             
+            Specify the chain specification.
+            
+            It can be one of the predefined ones (dev, local, or staging) or it can be a path to a file with the
+            chainspec (such as one exported by the `build-spec` subcommand).
+    -l, --log <LOG_PATTERN>...           
+            Sets a custom logging filter. Syntax is <target>=<level>, e.g. -lsync=debug.
+            
+            Log levels (least to most verbose) are error, warn, info, debug, and trace. By default, all targets log
+            `info`. The global log level can be set with -l<level>.
+        --node-key <KEY>                 
+            The secret key to use for libp2p networking.
+            
+            The value is a string that is parsed according to the choice of `--node-key-type` as follows:
+            
+            `ed25519`: The value is parsed as a hex-encoded Ed25519 32 byte secret key, i.e. 64 hex characters.
+            
+            The value of this option takes precedence over `--node-key-file`.
+            
+            WARNING: Secrets provided as command-line arguments are easily exposed. Use of this option should be limited
+            to development and testing. To use an externally managed secret key, use `--node-key-file` instead.
+        --node-key-file <FILE>           
+            The file from which to read the node's secret key to use for libp2p networking.
+            
+            The contents of the file are parsed according to the choice of `--node-key-type` as follows:
+            
+            `ed25519`: The file must contain an unencoded 32 byte or hex encoded Ed25519 secret key.
+            
+            If the file does not exist, it is created with a newly generated secret key of the chosen type.
+        --node-key-type <TYPE>           
+            The type of secret key to use for libp2p networking.
+            
+            The secret key of the node is obtained as follows:
+            
+            * If the `--node-key` option is given, the value is parsed as a secret key according to the type. See the
+            documentation for `--node-key`.
+            
+            * If the `--node-key-file` option is given, the secret key is read from the specified file. See the
+            documentation for `--node-key-file`.
+            
+            * Otherwise, the secret key is read from a file with a predetermined, type-specific name from the chain-
+            specific network config directory inside the base directory specified by `--base-dir`. If this file
+            does not exist, it is created with a newly generated secret key of the chosen type.
+            
+            The node's secret key determines the corresponding public key and hence the node's peer ID in the context of
+            libp2p. [default: Ed25519]  [possible values: Ed25519]
+        --tracing-receiver <RECEIVER>    
+            Receiver to process tracing messages [default: Log]  [possible values: Log]
+
+        --tracing-targets <TARGETS>      
+            Sets a custom profiling filter. Syntax is the same as for logging: <target>=<level>
+

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -88,7 +88,7 @@ pub fn edgeware_mainnet_official() -> ChainSpec {
 
 /// Beresheet Testnet configuration
 pub fn edgeware_beresheet_official() -> ChainSpec {
-	match ChainSpec::from_json_bytes(&include_bytes!("../res/beresheetv2.chainspec.json")[..]) {
+	match ChainSpec::from_json_bytes(&include_bytes!("../res/beresheetv3.chainspec.json")[..]) {
 		Ok(spec) => spec,
 		Err(e) => panic!("{}", e),
 	}
@@ -160,12 +160,12 @@ pub fn testnet_genesis(
 	_balances: Vec<(AccountId, Balance)>,
 	vesting: Vec<(AccountId, BlockNumber, BlockNumber, Balance)>,
 	_founder_allocation: Vec<(AccountId, Balance)>,
-	force_endow_initial_authorities: bool,
+	create_evm_alice: bool,
 ) -> GenesisConfig {
 	let alice_evm_account_id = H160::from_str("19e7e376e7c213b7e7e7e46cc70a5dd086daff2a").unwrap();
 	let mut evm_accounts = BTreeMap::new();
 
-	if force_endow_initial_authorities {
+	if create_evm_alice {
 		evm_accounts.insert(alice_evm_account_id, pallet_evm::GenesisAccount {
 			nonce: 0.into(),
 			balance: U256::from(123456_123_000_000_000_000_000u128),
@@ -191,16 +191,14 @@ pub fn testnet_genesis(
 		]
 	});
 
-	if force_endow_initial_authorities {
-		initial_authorities.iter().for_each(|x| {
-			if !endowed_accounts.contains(&x.0) {
-				endowed_accounts.push(x.0.clone());
-			}
-			if !endowed_accounts.contains(&x.1) {
-				endowed_accounts.push(x.1.clone());
-			}
-		});
-	}
+	initial_authorities.iter().for_each(|x| {
+		if !endowed_accounts.contains(&x.0) {
+			endowed_accounts.push(x.0.clone());
+		}
+		if !endowed_accounts.contains(&x.1) {
+			endowed_accounts.push(x.1.clone());
+		}
+	});
 
 	const STASH: Balance = 100000000 * DOLLARS;
 	let endowed_balances: Vec<(AccountId, Balance)> = endowed_accounts.iter().map(|k| (k.clone(), STASH)).collect();
@@ -273,7 +271,7 @@ fn edgeware_testnet_config_genesis() -> GenesisConfig {
 	testnet_genesis(
 		initial_authorities,
 		crate::testnet_fixtures::get_testnet_root_key(),
-		None,
+		Some(vec![]),
 		true,
 		balances,
 		vec![],

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -160,15 +160,19 @@ pub fn testnet_genesis(
 	_balances: Vec<(AccountId, Balance)>,
 	vesting: Vec<(AccountId, BlockNumber, BlockNumber, Balance)>,
 	_founder_allocation: Vec<(AccountId, Balance)>,
+	force_endow_initial_authorities: bool,
 ) -> GenesisConfig {
 	let alice_evm_account_id = H160::from_str("19e7e376e7c213b7e7e7e46cc70a5dd086daff2a").unwrap();
 	let mut evm_accounts = BTreeMap::new();
-	evm_accounts.insert(alice_evm_account_id, pallet_evm::GenesisAccount {
-		nonce: 0.into(),
-		balance: U256::from(123456_123_000_000_000_000_000u128),
-		storage: BTreeMap::new(),
-		code: vec![],
-	});
+
+	if force_endow_initial_authorities {
+		evm_accounts.insert(alice_evm_account_id, pallet_evm::GenesisAccount {
+			nonce: 0.into(),
+			balance: U256::from(123456_123_000_000_000_000_000u128),
+			storage: BTreeMap::new(),
+			code: vec![],
+		});
+	}
 
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
@@ -187,14 +191,16 @@ pub fn testnet_genesis(
 		]
 	});
 
-	initial_authorities.iter().for_each(|x| {
-		if !endowed_accounts.contains(&x.0) {
-			endowed_accounts.push(x.0.clone());
-		}
-		if !endowed_accounts.contains(&x.1) {
-			endowed_accounts.push(x.1.clone());
-		}
-	});
+	if force_endow_initial_authorities {
+		initial_authorities.iter().for_each(|x| {
+			if !endowed_accounts.contains(&x.0) {
+				endowed_accounts.push(x.0.clone());
+			}
+			if !endowed_accounts.contains(&x.1) {
+				endowed_accounts.push(x.1.clone());
+			}
+		});
+	}
 
 	const STASH: Balance = 100000000 * DOLLARS;
 	let endowed_balances: Vec<(AccountId, Balance)> = endowed_accounts.iter().map(|k| (k.clone(), STASH)).collect();
@@ -262,7 +268,7 @@ fn edgeware_testnet_config_genesis() -> GenesisConfig {
 		.filter(|b| b.1 > 0)
 		.collect();
 
-	let initial_authorities = crate::testnet_fixtures::get_mtestnet_initial_authorities();
+	let initial_authorities = crate::testnet_fixtures::get_beresheet_initial_authorities();
 
 	testnet_genesis(
 		initial_authorities,
@@ -272,6 +278,7 @@ fn edgeware_testnet_config_genesis() -> GenesisConfig {
 		balances,
 		vec![],
 		crate::mainnet_fixtures::get_commonwealth_allocation(),
+		false,
 	)
 }
 
@@ -284,7 +291,7 @@ pub fn edgeware_testnet_config(testnet_name: String, testnet_node_name: String) 
 			"tokenSymbol": "tEDG"
 		}"#;
 	let properties = serde_json::from_str(data).unwrap();
-	let boot_nodes = crate::testnet_fixtures::get_mtestnet_bootnodes();
+	let boot_nodes = crate::testnet_fixtures::get_beresheet_bootnodes();
 
 	ChainSpec::from_genesis(
 		&testnet_name,
@@ -319,6 +326,7 @@ fn multi_development_config_genesis() -> GenesisConfig {
 		vec![],
 		vec![],
 		vec![],
+		true,
 	)
 }
 
@@ -332,6 +340,7 @@ pub fn development_config_genesis() -> GenesisConfig {
 		vec![],
 		vec![],
 		vec![],
+		true,
 	)
 }
 
@@ -392,6 +401,7 @@ fn local_testnet_genesis() -> GenesisConfig {
 		vec![],
 		vec![],
 		vec![],
+		true,
 	)
 }
 

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -191,6 +191,8 @@ pub fn testnet_genesis(
 		]
 	});
 
+	endowed_accounts.push(_root_key.clone());
+
 	initial_authorities.iter().for_each(|x| {
 		if !endowed_accounts.contains(&x.0) {
 			endowed_accounts.push(x.0.clone());

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -55,8 +55,8 @@ impl SubstrateCli for Cli {
 			"multi-dev" | "multi" => Box::new(chain_spec::multi_development_config()),
 			"local" => Box::new(chain_spec::local_testnet_config()),
 			"testnet-conf" => Box::new(chain_spec::edgeware_testnet_config(
-				"Beresheet v2".to_string(),
-				"beresheet_v2_edgeware_testnet".to_string(),
+				"Beresheet v3".to_string(),
+				"beresheet_v3_edgeware_testnet".to_string(),
 			)),
 			"mainnet-conf" => Box::new(chain_spec::edgeware_mainnet_config()),
 			"beresheet" => Box::new(chain_spec::edgeware_beresheet_official()),

--- a/node/cli/src/testnet_fixtures.rs
+++ b/node/cli/src/testnet_fixtures.rs
@@ -27,12 +27,12 @@ use sp_finality_grandpa::AuthorityId as GrandpaId;
 
 /// Testnet root key
 pub fn get_testnet_root_key() -> AccountId {
-	// 5G8jA2TLTQqnofx2jCE1MAtaZNqnJf1ujv7LdZBv2LGznJE2
+	// Beresheet sudo key: 5HVniu9naSbxjFLYBUn6aUTpExoxBzweJCQGRT2GZTMsr5a7
 	return hex!["f04eaed79cba531626964ba59d727b670524247c92cdd0b5f5da04c8eccb796b"].into();
 }
 
-/// MTestnet bootnodes (network compatible from Edgeware mainnet launch)
-pub fn get_mtestnet_bootnodes() -> Vec<MultiaddrWithPeerId> {
+/// Beresheet bootnodes
+pub fn get_beresheet_bootnodes() -> Vec<MultiaddrWithPeerId> {
 	return vec![
 		"/ip4/45.77.148.197/tcp/30333/p2p/12D3KooWGq9cJfDdY3Mg7TZGZpLFTyMkdNB8G2gKCr2HQQgdcxwX"
 			.parse()
@@ -52,8 +52,8 @@ pub fn get_mtestnet_bootnodes() -> Vec<MultiaddrWithPeerId> {
 	];
 }
 
-/// Testnet initial authorities
-pub fn get_mtestnet_initial_authorities() -> Vec<(
+/// Beresheet initial authorities
+pub fn get_beresheet_initial_authorities() -> Vec<(
 	AccountId,
 	AccountId,
 	GrandpaId,

--- a/node/executor/Cargo.toml
+++ b/node/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-executor"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 description = "Edgeware implementation using a substrate node."
 edition = "2018"
@@ -19,9 +19,9 @@ sp-core = { version = "3.0" }
 sp-trie = { version = "3.0" }
 frame-benchmarking = { version = "3.0" }
 
-edgeware-primitives = { version = "3.3.5", path = "../primitives" }
-edgeware-runtime = { version = "3.3.5", path = "../runtime" }
-edgeware-runtime-interface = { version = "3.3.5", path = "../runtime-interface" }
+edgeware-primitives = { version = "3.3.6", path = "../primitives" }
+edgeware-runtime = { version = "3.3.6", path = "../runtime" }
+edgeware-runtime-interface = { version = "3.3.6", path = "../runtime-interface" }
 
 [dev-dependencies]
 sp-runtime = { version = "3.0" }

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-primitives"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-rpc-client"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-rpc"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/node/runtime-interface/Cargo.toml
+++ b/node/runtime-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-runtime-interface"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 description = "Edgeware runtime interface helpers and functions"
 edition = "2018"

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgeware-runtime"
-version = "3.3.5"
+version = "3.3.6"
 authors = ["Commonwealth Labs <hello@commonwealth.im>"]
 edition = "2018"
 build = "build.rs"
@@ -46,7 +46,7 @@ sp-offchain = { version = "3.0", default-features = false }
 sp-npos-elections = { version = "3.0", default-features = false }
 
 # edgeware primitives
-edgeware-primitives = { version = "3.3.5", path = "../primitives", default-features = false }
+edgeware-primitives = { version = "3.3.6", path = "../primitives", default-features = false }
 edgeware-evm-tracer = { path = "../evm_tracer", default-features = false }
 edgeware-rpc-primitives-debug = { path = "../debug", default-features = false }
 edgeware-rpc-primitives-txpool = { path = "../txpool", default-features = false }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -149,8 +149,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 10051,
-	impl_version: 10051,
+	spec_version: 10052,
+	impl_version: 10052,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };
@@ -1260,49 +1260,9 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
-	(
-		custom_migration::Upgrade,
-		// custom_migration::GrandpaStoragePrefixMigration
-	),
 >;
 
 pub type Extrinsic = <Block as BlockT>::Extrinsic;
-
-/// Custom runtime upgrade to execute the balances migration before the account
-/// migration.
-mod custom_migration {
-	use super::*;
-	use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
-
-	pub struct Upgrade;
-	impl pallet_elections_phragmen::migrations::v3::V2ToV3 for Upgrade {
-		type AccountId = AccountId;
-		type Balance = Balance;
-		type Module = PhragmenElection;
-	}
-
-	impl OnRuntimeUpgrade for Upgrade {
-		fn on_runtime_upgrade() -> Weight {
-			let mut weight = 0;
-			// custom migration for edgeware.
-			weight += frame_system::migrations::migrate_for_edgeware::<Runtime>();
-			// old VotingBond
-			let old_voter_bond: Balance = 10 * DOLLARS;
-			// old CandidacyBond
-			let old_candidacy_bond: Balance = 1_000 * DOLLARS;
-			// elections migrations.
-			pallet_elections_phragmen::migrations::v3::migrate_voters_to_recorded_deposit::<Self>(old_voter_bond);
-			pallet_elections_phragmen::migrations::v3::migrate_candidates_to_recorded_deposit::<Self>(
-				old_candidacy_bond,
-			);
-			pallet_elections_phragmen::migrations::v3::migrate_runners_up_to_recorded_deposit::<Self>(
-				old_candidacy_bond,
-			);
-			pallet_elections_phragmen::migrations::v3::migrate_members_to_recorded_deposit::<Self>(old_candidacy_bond);
-			weight
-		}
-	}
-}
 
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {


### PR DESCRIPTION
This upgrade should be executed *after* the Wako upgrade as been run on mainnet, as it leaves out important migrations that are used to get us to Substrate 3.0.0. We will also use this as the genesis for the Beresheet v3 testnet

- remove balance refcount and phragmenElection migrations
- set up new testnet config, leave out Alice accounts in Beresheet
- recompile with beresheetv3 chainspec
- bump version
